### PR TITLE
CPP fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,14 +2,14 @@
 
 All notable changes to this project will be documented in this file.
 
-## [0.2.1] - 2025-03-03
+## [0.2.1] - 2025-03-12
 
 ### Fixes
 - changing C++ impl from const to constexpr
 - Fix multiple inheritance issues for C++ header
 
 ### Enhancements
-- Add new test for multiple interface inheritance issue
+- Add a new test for interface inheritance
 
 ## [0.2.0] - 2024-10-17
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.2.1] - 2025-02-21
+
+### Fixes
+- changing C++ impl from const to constexpr
+- Fix multiple inheritance issues for C++ header
+
 ## [0.2.0] - 2024-10-17
 
 ### Enhancements

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,14 @@
 
 All notable changes to this project will be documented in this file.
 
-## [0.2.1] - 2025-02-21
+## [0.2.1] - 2025-03-03
 
 ### Fixes
 - changing C++ impl from const to constexpr
 - Fix multiple inheritance issues for C++ header
+
+### Enhancements
+- Add new test for multiple interface inheritance issue
 
 ## [0.2.0] - 2024-10-17
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,4 +27,4 @@ strip = true
 panic = "abort"
 
 [workspace.package]
-version = "0.2.0"
+version = "0.2.1"

--- a/idlc_codegen_cpp/src/generator.rs
+++ b/idlc_codegen_cpp/src/generator.rs
@@ -28,7 +28,7 @@ impl idlc_codegen::SplitInvokeGenerator for Generator {
                     let value = &c.value;
 
                     result.push_str(&format!(
-                        "static const {cnt_ty} {ident} = {ty}({value});\n\n"
+                        "static constexpr {cnt_ty} {ident} = {ty}({value});\n\n"
                     ));
                 }
                 Node::Struct(s) => {

--- a/idlc_codegen_cpp/src/interface/mod.rs
+++ b/idlc_codegen_cpp/src/interface/mod.rs
@@ -109,7 +109,7 @@ pub fn emit_interface_impl(interface: &Interface) -> String {
     }
 
     if !base_iface.is_empty() {
-        let base_ifaces =  base_iface.split_whitespace();
+        let base_ifaces = base_iface.split_whitespace();
         let mut ifaces = String::new();
         for iface in base_ifaces {
             ifaces.push_str(&format!("public {iface}, "));

--- a/idlc_codegen_cpp/src/interface/mod.rs
+++ b/idlc_codegen_cpp/src/interface/mod.rs
@@ -109,14 +109,8 @@ pub fn emit_interface_impl(interface: &Interface) -> String {
     }
 
     if !base_iface.is_empty() {
-        let base_ifaces = base_iface.split_whitespace();
-        let mut ifaces = String::new();
-        for iface in base_ifaces {
-            ifaces.push_str(&format!("public {iface}, "));
-        }
-        ifaces.pop();
-        ifaces.pop();
-        base_iface = format!(": {ifaces}");
+        let first_base_iface = base_iface.split_whitespace().next().unwrap();
+        base_iface = format!(": public {first_base_iface} ");
     }
 
     format!(

--- a/idlc_codegen_cpp/src/interface/mod.rs
+++ b/idlc_codegen_cpp/src/interface/mod.rs
@@ -24,7 +24,7 @@ pub fn emit_interface_impl(interface: &Interface) -> String {
             InterfaceNode::Const(c) => {
                 constants.push_str(&format!(
                     r#"
-    static const {} {} = {}({});"#,
+    static constexpr {} {} = {}({});"#,
                     change_primitive(c.r#type),
                     c.ident,
                     change_const_primitive(c.r#type),
@@ -34,7 +34,7 @@ pub fn emit_interface_impl(interface: &Interface) -> String {
             InterfaceNode::Error(e) => {
                 errors.push_str(&format!(
                     r#"
-    static const int32_t {} = INT32_C({});"#,
+    static constexpr int32_t {} = INT32_C({});"#,
                     e.ident, e.value
                 ));
             }
@@ -61,7 +61,7 @@ pub fn emit_interface_impl(interface: &Interface) -> String {
             InterfaceNode::Const(c) => {
                 constants.push_str(&format!(
                     r#"
-    static const {} {} = {}({});"#,
+    static constexpr {} {} = {}({});"#,
                     change_primitive(c.r#type),
                     c.ident,
                     change_const_primitive(c.r#type),
@@ -71,7 +71,7 @@ pub fn emit_interface_impl(interface: &Interface) -> String {
             InterfaceNode::Error(e) => {
                 errors.push_str(&format!(
                     r#"
-    static const int32_t {} = INT32_C({});"#,
+    static constexpr int32_t {} = INT32_C({});"#,
                     e.ident, e.value
                 ));
             }
@@ -95,7 +95,7 @@ pub fn emit_interface_impl(interface: &Interface) -> String {
                 ));
                 op_codes.push_str(&format!(
                     r#"
-    static const ObjectOp OP_{} = {};"#,
+    static constexpr ObjectOp OP_{} = {};"#,
                     f.ident, f.id,
                 ));
                 implementations.push_str(&functions::implementation::emit(
@@ -109,7 +109,14 @@ pub fn emit_interface_impl(interface: &Interface) -> String {
     }
 
     if !base_iface.is_empty() {
-        base_iface = format!(": public {base_iface}");
+        let base_ifaces =  base_iface.split_whitespace();
+        let mut ifaces = String::new();
+        for iface in base_ifaces {
+            ifaces.push_str(&format!("public {iface}, "));
+        }
+        ifaces.pop();
+        ifaces.pop();
+        base_iface = format!(": {ifaces}");
     }
 
     format!(

--- a/idlc_codegen_rust/src/ident.rs
+++ b/idlc_codegen_rust/src/ident.rs
@@ -3,7 +3,7 @@
 
 #[derive(Debug, Clone, Copy)]
 pub struct EscapedIdent<'a>(&'a idlc_mir::Ident);
-impl<'a> std::fmt::Display for EscapedIdent<'a> {
+impl std::fmt::Display for EscapedIdent<'_> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "r#{}", &self.0)
     }

--- a/idlc_mir_passes/src/interface_verifier.rs
+++ b/idlc_mir_passes/src/interface_verifier.rs
@@ -18,7 +18,7 @@ impl<'mir> InterfaceVerifier<'mir> {
     }
 }
 
-impl<'mir> MirCompilerPass<'_> for InterfaceVerifier<'mir> {
+impl MirCompilerPass<'_> for InterfaceVerifier<'_> {
     type Output = ();
 
     fn run_pass(&'_ mut self) -> Self::Output {

--- a/tests/c/header.h
+++ b/tests/c/header.h
@@ -41,6 +41,11 @@ struct CTest1 {
   uint32_t value;
 };
 
+struct CTest3 {
+  uint32_t refs;
+  uint32_t value;
+};
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -116,6 +121,8 @@ int32_t itest1_test_obj_array_out(struct CTest1 *ctx, Object (*o_ptr)[3],
 
 int32_t itest1_objects_in_struct(struct CTest1 *ctx, const ObjInStruct *input,
                                  ObjInStruct *output);
+
+int32_t itest3_extra_test3(struct CTest1 *ctx, uint32_t *output_ptr);
 
 #ifdef __cplusplus
 }

--- a/tests/c/invoke.c
+++ b/tests/c/invoke.c
@@ -6,6 +6,7 @@
 #include <string.h>
 
 #include "ITest_invoke.h"
+#include "ITest3_invoke.h"
 #include "object.h"
 
 Object create_c_itest1(uint32_t value);
@@ -322,3 +323,126 @@ int32_t itest2_entrypoint(void *ctx, Object itest1) {
 ITest2_DEFINE_INVOKE(itest2_invoke, itest2_, void *);
 
 Object create_c_itest2() { return (Object){itest2_invoke, NULL}; }
+
+
+int32_t itest3_release(void *ctx) { return Object_OK; }
+
+int32_t itest3_retain(void *ctx) { return Object_OK; }
+
+int32_t itest3_extra_test3(struct CTest1 *ctx, uint32_t *output_ptr) {
+  *output_ptr = 0xdead;
+  return Object_OK;
+}
+
+int32_t itest3_test_f1(struct CTest1 *ctx, uint32_t a_val, uint32_t *b_ptr) {
+  return itest1_test_f1(ctx, a_val, b_ptr);
+}
+
+int32_t itest3_single_in(struct CTest1 *ctx, uint32_t input_val) {
+  return itest1_single_in(ctx, input_val);
+}
+
+int32_t itest3_single_out(struct CTest1 *ctx, uint32_t *output_ptr) {
+  return itest1_single_out(ctx, output_ptr);
+}
+
+int32_t itest3_single_primitive_in(struct CTest1 *ctx, const void *unused_ptr,
+                                   size_t unused_len, void *unused2_ptr,
+                                   size_t unused2_len, size_t *unused2_lenout,
+                                   uint32_t input_val) {
+  return itest1_single_in(ctx, input_val);
+}
+int32_t itest3_single_primitive_out(struct CTest1 *ctx, const void *unused_ptr,
+                                    size_t unused_len, void *unused2_ptr,
+                                    size_t unused2_len, size_t *unused2_lenout,
+                                    uint32_t *output_ptr) {
+  return itest1_single_out(ctx, output_ptr);
+}
+
+int32_t itest3_out_struct(struct CTest1 *ctx, Collection *output) {
+  return itest1_out_struct(ctx, output);
+}
+
+int32_t itest3_in_struct(struct CTest1 *ctx, const Collection *input) {
+  return itest1_in_struct(ctx, input);
+}
+
+int32_t itest3_out_small_struct(struct CTest1 *ctx, SingleEncapsulated *output) {
+  return itest1_out_small_struct(ctx, output);
+}
+
+int32_t itest3_in_small_struct(struct CTest1 *ctx, const SingleEncapsulated *input) {
+  return itest1_in_small_struct(ctx, input);
+}
+
+int32_t itest3_multiple_primitive(struct CTest1 *ctx, const void *unused_ptr,
+                                  size_t unused_len, void *unused2_ptr,
+                                  size_t unused2_len, size_t *unused2_lenout,
+                                  uint16_t input_val, uint16_t *output_ptr,
+                                  Object unused3_val, Object *unused4_ptr,
+                                  uint32_t input2_val, uint64_t *output2_ptr,
+                                  void *unused5_ptr, size_t unused5_len,
+                                  size_t *unused5_lenout) {
+  return itest1_multiple_primitive(ctx, unused_ptr, unused_len, unused2_ptr,
+                            unused2_len,unused2_lenout,input_val, output_ptr,
+                            unused3_val, unused4_ptr, input2_val, output2_ptr,
+                            unused5_ptr, unused5_len, unused5_lenout);
+}
+
+int32_t
+itest3_primitive_plus_struct_in(struct CTest1 *ctx,
+                                const SingleEncapsulated *encapsulated_ptr,
+                                uint32_t magic_val) {
+  return itest1_primitive_plus_struct_in(ctx, encapsulated_ptr, magic_val);
+}
+
+int32_t itest3_primitive_plus_struct_out(struct CTest1 *ctx,
+                                         SingleEncapsulated *encapsulated_ptr,
+                                         uint32_t *magic_ptr) {
+  return itest1_primitive_plus_struct_out(ctx, encapsulated_ptr, magic_ptr);
+}
+
+int32_t itest3_primitive_array_in_struct(struct CTest1 *ctx,
+                                         ArrInStruct *arr_ptr,
+                                         uint32_t *magic_ptr) {
+  return itest1_primitive_array_in_struct(ctx, arr_ptr, magic_ptr);
+}
+
+int32_t itest3_bundled_with_unbundled(struct CTest1 *ctx,
+                                      const SingleEncapsulated *bundled_ptr,
+                                      uint32_t magic_val,
+                                      const Collection *unbundled_ptr) {
+  return itest1_bundled_with_unbundled(ctx, bundled_ptr, magic_val, unbundled_ptr);
+}
+
+int32_t itest3_struct_array_in(struct CTest1 *ctx, const Collection *s_in_ptr, size_t s_in_len) {
+  return itest1_struct_array_in(ctx, s_in_ptr, s_in_len);
+}
+
+int32_t itest3_struct_array_out(struct CTest1 *ctx, Collection *s_out_ptr, size_t s_out_len, size_t *s_out_lenout) {
+  return itest1_struct_array_out(ctx, s_out_ptr, s_out_len, s_out_lenout);
+}
+
+int32_t itest3_well_documented_method(struct CTest1 *ctx, uint32_t foo_val,
+                                           uint32_t *bar_ptr) {
+  return itest1_well_documented_method_real(ctx, foo_val, bar_ptr);
+}
+
+int32_t itest3_test_obj_array_in(struct CTest1 *ctx,
+                                 const Object (*o_in_ptr)[3], uint32_t *a_ptr) {
+  return Object_OK;
+}
+
+int32_t itest3_test_obj_array_out(struct CTest1 *ctx, Object (*o_ptr)[3],
+                                  uint32_t *a_ptr) {
+  return Object_OK;
+}
+
+int32_t itest3_objects_in_struct(struct CTest1 *ctx, const ObjInStruct *input,
+                                 ObjInStruct *output) {
+  return itest1_objects_in_struct(ctx, input, output);
+}
+
+ITest3_DEFINE_INVOKE(itest3_invoke, itest3_, void *);
+
+Object create_c_itest3() { return (Object){itest3_invoke, NULL}; }

--- a/tests/cpp/main.cpp
+++ b/tests/cpp/main.cpp
@@ -4,57 +4,58 @@
 #include <object.h>
 #include <stdint.h>
 #include <string.h>
+#include <stdio.h>
+#include <stdlib.h>
 
-namespace cpp {
 #include "ITest.hpp"
 #include "ITest_invoke.hpp"
-} // namespace cpp
 
+namespace c {
 #include "../c/header.h"
+}
 
-using cpp::ProxyBase;
 
 extern "C" {
 Object create_cpp_itest1(uint32_t value);
 }
 
-class ITest1Impl : public cpp::ITest1ImplBase {
+class ITest1Impl : public ITest1ImplBase {
 public:
-  ITest1Impl(struct CTest1 ctest) { this->ctest = ctest; }
+  ITest1Impl(struct c::CTest1 ctest) { this->ctest = ctest; }
   ~ITest1Impl() {}
 
   int32_t test_f1(uint32_t a_val, uint32_t *b_ptr) {
-    return itest1_test_f1(&this->ctest, a_val, b_ptr);
+    return c::itest1_test_f1(&this->ctest, a_val, b_ptr);
   }
-  int32_t in_struct(const cpp::Collection &input_ref) {
-    return itest1_in_struct(&this->ctest, (const Collection *)(&input_ref));
+  int32_t in_struct(const Collection &input_ref) {
+    return c::itest1_in_struct(&this->ctest, (const c::Collection *)(&input_ref));
   }
-  int32_t out_struct(cpp::Collection &output_ref) {
-    return itest1_out_struct(&this->ctest, (Collection *)(&output_ref));
+  int32_t out_struct(Collection &output_ref) {
+    return c::itest1_out_struct(&this->ctest, (c::Collection *)(&output_ref));
   }
-  int32_t in_small_struct(const cpp::SingleEncapsulated &input_ref) {
-    return itest1_in_small_struct(&this->ctest, (const SingleEncapsulated *)(&input_ref));
+  int32_t in_small_struct(const SingleEncapsulated &input_ref) {
+    return c::itest1_in_small_struct(&this->ctest, (const c::SingleEncapsulated *)(&input_ref));
   }
-  int32_t out_small_struct(cpp::SingleEncapsulated &output_ref) {
-    return itest1_out_small_struct(&this->ctest, (SingleEncapsulated *)(&output_ref));
+  int32_t out_small_struct(SingleEncapsulated &output_ref) {
+    return c::itest1_out_small_struct(&this->ctest, (c::SingleEncapsulated *)(&output_ref));
   }
   int32_t single_out(uint32_t *output_ptr) {
-    return itest1_single_out(&this->ctest, output_ptr);
+    return c::itest1_single_out(&this->ctest, output_ptr);
   }
   int32_t single_in(uint32_t input_val) {
-    return itest1_single_in(&this->ctest, input_val);
+    return c::itest1_single_in(&this->ctest, input_val);
   }
   int32_t single_primitive_in(const void *unused_ptr, size_t unused_len,
                               void *unused2_ptr, size_t unused2_len,
                               size_t *unused2_lenout, uint32_t input_val) {
-    return itest1_single_primitive_in(&this->ctest, unused_ptr, unused_len,
+    return c::itest1_single_primitive_in(&this->ctest, unused_ptr, unused_len,
                                       unused2_ptr, unused2_len, unused2_lenout,
                                       input_val);
   }
   int32_t single_primitive_out(const void *unused_ptr, size_t unused_len,
                                void *unused2_ptr, size_t unused2_len,
                                size_t *unused2_lenout, uint32_t *output_ptr) {
-    return itest1_single_primitive_out(&this->ctest, unused_ptr, unused_len,
+    return c::itest1_single_primitive_out(&this->ctest, unused_ptr, unused_len,
                                        unused2_ptr, unused2_len, unused2_lenout,
                                        output_ptr);
   }
@@ -67,7 +68,7 @@ public:
                              size_t unused5_len, size_t *unused5_lenout) {
     Object unused4_val = unused4_ref.get();
 
-    CHECK_OK(itest1_multiple_primitive(
+    CHECK_OK(c::itest1_multiple_primitive(
         &this->ctest, unused_ptr, unused_len, unused2_ptr, unused2_len,
         unused2_lenout, input_val, output_ptr, unused3_ref.get(), &unused4_val,
         input2_val, output2_ptr, unused5_ptr, unused5_len, unused5_lenout));
@@ -77,61 +78,61 @@ public:
   }
 
   int32_t
-  primitive_plus_struct_in(const cpp::SingleEncapsulated &encapsulated_ref,
+  primitive_plus_struct_in(const SingleEncapsulated &encapsulated_ref,
                            uint32_t magic_val) {
-    return itest1_primitive_plus_struct_in(
-        &this->ctest, (const SingleEncapsulated *)&encapsulated_ref, magic_val);
+    return c::itest1_primitive_plus_struct_in(
+        &this->ctest, (const c::SingleEncapsulated *)&encapsulated_ref, magic_val);
   }
-  int32_t primitive_plus_struct_out(cpp::SingleEncapsulated &encapsulated_ref,
+  int32_t primitive_plus_struct_out(SingleEncapsulated &encapsulated_ref,
                                     uint32_t *magic_ptr) {
-    return itest1_primitive_plus_struct_out(
-        &this->ctest, (SingleEncapsulated *)&encapsulated_ref, magic_ptr);
+    return c::itest1_primitive_plus_struct_out(
+        &this->ctest, (c::SingleEncapsulated *)&encapsulated_ref, magic_ptr);
   }
-  int32_t primitive_array_in_struct(cpp::ArrInStruct &arr_ref,
+  int32_t primitive_array_in_struct(ArrInStruct &arr_ref,
                                     uint32_t *magic_ptr) {
-    return itest1_primitive_array_in_struct(
-        &this->ctest, (ArrInStruct *)&arr_ref, magic_ptr);
+    return c::itest1_primitive_array_in_struct(
+        &this->ctest, (c::ArrInStruct *)&arr_ref, magic_ptr);
   }
-  int32_t bundled_with_unbundled(const cpp::SingleEncapsulated &bundled_ref,
+  int32_t bundled_with_unbundled(const SingleEncapsulated &bundled_ref,
                                  uint32_t magic_val,
-                                 const cpp::Collection &unbundled_ref) {
-    return itest1_bundled_with_unbundled(
-        &this->ctest, (const SingleEncapsulated *)&bundled_ref, magic_val,
-        (const Collection *)&unbundled_ref);
+                                 const Collection &unbundled_ref) {
+    return c::itest1_bundled_with_unbundled(
+        &this->ctest, (const c::SingleEncapsulated *)&bundled_ref, magic_val,
+        (const c::Collection *)&unbundled_ref);
   }
-  int32_t struct_array_in(const cpp::Collection *s_in_ptr, size_t s_in_len) {
+  int32_t struct_array_in(const Collection *s_in_ptr, size_t s_in_len) {
     return itest1_struct_array_in(
-        &this->ctest, (const Collection *)s_in_ptr, s_in_len);
+        &this->ctest, (const c::Collection *)s_in_ptr, s_in_len);
   }
-  int32_t struct_array_out( cpp::Collection *s_out_ptr, size_t s_out_len, size_t *s_out_lenout) {
-    return itest1_struct_array_out(
-        &this->ctest, (Collection *)s_out_ptr, s_out_len, s_out_lenout);
+  int32_t struct_array_out( Collection *s_out_ptr, size_t s_out_len, size_t *s_out_lenout) {
+    return c::itest1_struct_array_out(
+        &this->ctest, (c::Collection *)s_out_ptr, s_out_len, s_out_lenout);
   }
   int32_t well_documented_method(uint32_t foo_val, uint32_t *bar_ptr) {
-    return itest1_well_documented_method_real(&this->ctest, foo_val, bar_ptr);
+    return c::itest1_well_documented_method_real(&this->ctest, foo_val, bar_ptr);
   }
-  int32_t test_obj_array_in(const cpp::ITest1 (&o_in_ptr)[3], uint32_t *a_ptr) {
+  int32_t test_obj_array_in(const ITest1 (&o_in_ptr)[3], uint32_t *a_ptr) {
     for (size_t i = 0; i < 3; i++) {
       Object o = (o_in_ptr)[i].get();
       if (!Object_isNull(o)) {
-        CHECK_OK(test_singular_object(o));
+        CHECK_OK(c::test_singular_object(o));
       }
     }
     *a_ptr = SUCCESS_FLAG;
     return Object_OK;
   }
-  int32_t test_obj_array_out(cpp::ITest1 (&out_ref)[3], uint32_t *a_ptr) {
+  int32_t test_obj_array_out(ITest1 (&out_ref)[3], uint32_t *a_ptr) {
     (out_ref)[0] = create_cpp_itest1(0);
     (out_ref)[1] = create_cpp_itest1(1);
     (out_ref)[2] = create_cpp_itest1(2);
     *a_ptr = SUCCESS_FLAG;
     return Object_OK;
   }
-  int32_t objects_in_struct(const cpp::ObjInStruct &input_ref,
-                            cpp::ObjInStruct &output_ref) {
-    CHECK_OK(test_singular_object(input_ref.first_obj));
+  int32_t objects_in_struct(const ObjInStruct &input_ref,
+                            ObjInStruct &output_ref) {
+    CHECK_OK(c::test_singular_object(input_ref.first_obj));
     ASSERT(Object_isNull(input_ref.should_be_empty));
-    CHECK_OK(test_singular_object(input_ref.second_obj));
+    CHECK_OK(c::test_singular_object(input_ref.second_obj));
 
     for (size_t i = 0; i < sizeof(input_ref.p1) / sizeof(input_ref.p1[0]);
          i++) {
@@ -150,34 +151,34 @@ public:
   }
 
 private:
-  struct CTest1 ctest;
+  struct c::CTest1 ctest;
 };
 
 extern "C" {
 
 Object create_cpp_itest1(uint32_t value) {
-  struct CTest1 ctest = {.refs = 1, .value = value};
+  struct c::CTest1 ctest = {.refs = 1, .value = value};
   ITest1Impl *me = new ITest1Impl(ctest);
   if (me == nullptr) {
     return Object_NULL;
   }
 
-  return (Object){cpp::ImplBase::invoke, me};
+  return (Object){ImplBase::invoke, me};
 }
 }
 
-class ITest2Impl : public cpp::ITest2ImplBase {
+class ITest2Impl : public ITest2ImplBase {
 public:
-  int32_t entrypoint(const cpp::ITest1 &o) {
-    struct CTest1 ctest = {.refs = 1, .value = 1};
+  int32_t entrypoint(const ITest1 &o) {
+    struct c::CTest1 ctest = {.refs = 1, .value = 1};
     ITest1Impl me(ctest);
     const Object itest1 = o.get();
     ASSERT(!Object_isNull(itest1));
-    CHECK_OK(test_singular_object(itest1));
+    CHECK_OK(c::test_singular_object(itest1));
 
-    cpp::ITest1 objects[3] = {create_cpp_itest1(1), Object_NULL,
+    ITest1 objects[3] = {create_cpp_itest1(1), Object_NULL,
                               create_cpp_itest1(2)};
-    cpp::ITest1 objects_out[3] = {Object_NULL, Object_NULL, Object_NULL};
+    ITest1 objects_out[3] = {Object_NULL, Object_NULL, Object_NULL};
     uint32_t a = 0;
     CHECK_OK(me.test_obj_array_in(objects, &a));
     ASSERT(a == SUCCESS_FLAG);
@@ -187,13 +188,13 @@ public:
 
     for (size_t i = 0; i < sizeof(objects) / sizeof(objects[0]); i++) {
 
-      CHECK_OK(test_singular_object(objects_out[i].get()));
+      CHECK_OK(c::test_singular_object(objects_out[i].get()));
     }
 
     const uint32_t VALID_PS[4] = {SUCCESS_FLAG, SUCCESS_FLAG, SUCCESS_FLAG,
                                   SUCCESS_FLAG};
 
-    cpp::ObjInStruct input_struct = {
+    ObjInStruct input_struct = {
         .first_obj = create_cpp_itest1(1),
         .should_be_empty = Object_NULL,
         .second_obj = create_cpp_itest1(2),
@@ -201,14 +202,14 @@ public:
     memcpy(&input_struct.p1, VALID_PS, sizeof(VALID_PS));
     memcpy(&input_struct.p2, VALID_PS, sizeof(VALID_PS));
     memcpy(&input_struct.p3, VALID_PS, sizeof(VALID_PS));
-    cpp::ObjInStruct output_struct{};
+    ObjInStruct output_struct{};
     CHECK_OK(me.objects_in_struct(input_struct, output_struct));
     ASSERT(memcmp(&output_struct.p1, VALID_PS, sizeof(VALID_PS)) == 0);
     ASSERT(memcmp(&output_struct.p2, VALID_PS, sizeof(VALID_PS)) == 0);
     ASSERT(memcmp(&output_struct.p3, VALID_PS, sizeof(VALID_PS)) == 0);
 
-    CHECK_OK(test_singular_object(output_struct.first_obj));
-    CHECK_OK(test_singular_object(output_struct.second_obj));
+    CHECK_OK(c::test_singular_object(output_struct.first_obj));
+    CHECK_OK(c::test_singular_object(output_struct.second_obj));
     ASSERT(Object_isNull(output_struct.should_be_empty));
 
     Object_ASSIGN_NULL(input_struct.first_obj);
@@ -231,6 +232,6 @@ Object create_cpp_itest2(void) {
   if (me == nullptr) {
     return Object_NULL;
   }
-  return (Object){cpp::ImplBase::invoke, me};
+  return (Object){ImplBase::invoke, me};
 }
 }

--- a/tests/cpp/main.cpp
+++ b/tests/cpp/main.cpp
@@ -238,3 +238,149 @@ Object create_cpp_itest2(void) {
   return (Object){ImplBase::invoke, me};
 }
 }
+
+class ITest3Impl : public ITest3ImplBase {
+public:
+  ITest3Impl() {}
+  ~ITest3Impl() {}
+  int32_t extra_test3(uint32_t *output_ptr) {
+    return c::itest3_extra_test3(&this->ctest, output_ptr);
+  }
+  int32_t test_f1(uint32_t a_val, uint32_t *b_ptr) {
+    return c::itest1_test_f1(&this->ctest, a_val, b_ptr);
+  }
+  int32_t in_struct(const Collection &input_ref) {
+    return c::itest1_in_struct(&this->ctest, (const c::Collection *)(&input_ref));
+  }
+  int32_t out_struct(Collection &output_ref) {
+    return c::itest1_out_struct(&this->ctest, (c::Collection *)(&output_ref));
+  }
+  int32_t in_small_struct(const SingleEncapsulated &input_ref) {
+    return c::itest1_in_small_struct(&this->ctest, (const c::SingleEncapsulated *)(&input_ref));
+  }
+  int32_t out_small_struct(SingleEncapsulated &output_ref) {
+    return c::itest1_out_small_struct(&this->ctest, (c::SingleEncapsulated *)(&output_ref));
+  }
+  int32_t single_out(uint32_t *output_ptr) {
+    return c::itest1_single_out(&this->ctest, output_ptr);
+  }
+  int32_t single_in(uint32_t input_val) {
+    return c::itest1_single_in(&this->ctest, input_val);
+  }
+  int32_t single_primitive_in(const void *unused_ptr, size_t unused_len,
+                              void *unused2_ptr, size_t unused2_len,
+                              size_t *unused2_lenout, uint32_t input_val) {
+    return c::itest1_single_primitive_in(&this->ctest, unused_ptr, unused_len,
+                                      unused2_ptr, unused2_len, unused2_lenout,
+                                      input_val);
+  }
+  int32_t single_primitive_out(const void *unused_ptr, size_t unused_len,
+                               void *unused2_ptr, size_t unused2_len,
+                               size_t *unused2_lenout, uint32_t *output_ptr) {
+    return c::itest1_single_primitive_out(&this->ctest, unused_ptr, unused_len,
+                                       unused2_ptr, unused2_len, unused2_lenout,
+                                       output_ptr);
+  }
+  int32_t multiple_primitive(const void *unused_ptr, size_t unused_len,
+                             void *unused2_ptr, size_t unused2_len,
+                             size_t *unused2_lenout, uint16_t input_val,
+                             uint16_t *output_ptr, const ProxyBase &unused3_ref,
+                             ProxyBase &unused4_ref, uint32_t input2_val,
+                             uint64_t *output2_ptr, void *unused5_ptr,
+                             size_t unused5_len, size_t *unused5_lenout) {
+    Object unused4_val = unused4_ref.get();
+
+    CHECK_OK(c::itest1_multiple_primitive(
+        &this->ctest, unused_ptr, unused_len, unused2_ptr, unused2_len,
+        unused2_lenout, input_val, output_ptr, unused3_ref.get(), &unused4_val,
+        input2_val, output2_ptr, unused5_ptr, unused5_len, unused5_lenout));
+
+    unused4_ref = ProxyBase(unused4_val);
+    return Object_OK;
+  }
+
+  int32_t
+  primitive_plus_struct_in(const SingleEncapsulated &encapsulated_ref,
+                           uint32_t magic_val) {
+    return c::itest1_primitive_plus_struct_in(
+        &this->ctest, (const c::SingleEncapsulated *)&encapsulated_ref, magic_val);
+  }
+  int32_t primitive_plus_struct_out(SingleEncapsulated &encapsulated_ref,
+                                    uint32_t *magic_ptr) {
+    return c::itest1_primitive_plus_struct_out(
+        &this->ctest, (c::SingleEncapsulated *)&encapsulated_ref, magic_ptr);
+  }
+  int32_t primitive_array_in_struct(ArrInStruct &arr_ref,
+                                    uint32_t *magic_ptr) {
+    return c::itest1_primitive_array_in_struct(
+        &this->ctest, (c::ArrInStruct *)&arr_ref, magic_ptr);
+  }
+  int32_t bundled_with_unbundled(const SingleEncapsulated &bundled_ref,
+                                 uint32_t magic_val,
+                                 const Collection &unbundled_ref) {
+    return c::itest1_bundled_with_unbundled(
+        &this->ctest, (const c::SingleEncapsulated *)&bundled_ref, magic_val,
+        (const c::Collection *)&unbundled_ref);
+  }
+  int32_t struct_array_in(const Collection *s_in_ptr, size_t s_in_len) {
+    return itest1_struct_array_in(
+        &this->ctest, (const c::Collection *)s_in_ptr, s_in_len);
+  }
+  int32_t struct_array_out( Collection *s_out_ptr, size_t s_out_len, size_t *s_out_lenout) {
+    return c::itest1_struct_array_out(
+        &this->ctest, (c::Collection *)s_out_ptr, s_out_len, s_out_lenout);
+  }
+  int32_t well_documented_method(uint32_t foo_val, uint32_t *bar_ptr) {
+    return c::itest1_well_documented_method_real(&this->ctest, foo_val, bar_ptr);
+  }
+  int32_t test_obj_array_in(const ITest1 (&o_in_ptr)[3], uint32_t *a_ptr) {
+    for (size_t i = 0; i < 3; i++) {
+      Object o = (o_in_ptr)[i].get();
+      if (!Object_isNull(o)) {
+        CHECK_OK(c::test_singular_object(o));
+      }
+    }
+    *a_ptr = SUCCESS_FLAG;
+    return Object_OK;
+  }
+  int32_t test_obj_array_out(ITest1 (&out_ref)[3], uint32_t *a_ptr) {
+    (out_ref)[0] = create_cpp_itest1(0);
+    (out_ref)[1] = create_cpp_itest1(1);
+    (out_ref)[2] = create_cpp_itest1(2);
+    *a_ptr = SUCCESS_FLAG;
+    return Object_OK;
+  }
+  int32_t objects_in_struct(const ObjInStruct &input_ref,
+                            ObjInStruct &output_ref) {
+    CHECK_OK(c::test_singular_object(input_ref.first_obj));
+    ASSERT(Object_isNull(input_ref.should_be_empty));
+    CHECK_OK(c::test_singular_object(input_ref.second_obj));
+
+    for (size_t i = 0; i < sizeof(input_ref.p1) / sizeof(input_ref.p1[0]);
+         i++) {
+      ASSERT(input_ref.p1[i] == SUCCESS_FLAG);
+      ASSERT(input_ref.p2[i] == SUCCESS_FLAG);
+      ASSERT(input_ref.p3[i] == SUCCESS_FLAG);
+
+      output_ref.p1[i] = SUCCESS_FLAG;
+      output_ref.p2[i] = SUCCESS_FLAG;
+      output_ref.p3[i] = SUCCESS_FLAG;
+    }
+    output_ref.first_obj = create_cpp_itest1(1);
+    output_ref.second_obj = create_cpp_itest1(2);
+    output_ref.should_be_empty = Object_NULL;
+    return Object_OK;
+  }
+private:
+  struct c::CTest1 ctest;
+};
+
+extern "C" {
+Object create_cpp_itest3() {
+  ITest3Impl *me = new ITest3Impl();
+  if (me == nullptr) {
+    return Object_NULL;
+  }
+  return (Object){ImplBase::invoke, me};
+}
+}

--- a/tests/cpp/main.cpp
+++ b/tests/cpp/main.cpp
@@ -10,6 +10,9 @@
 #include "ITest.hpp"
 #include "ITest_invoke.hpp"
 
+#include "ITest3.hpp"
+#include "ITest3_invoke.hpp"
+
 namespace c {
 #include "../c/header.h"
 }

--- a/tests/idl/ITest3.idl
+++ b/tests/idl/ITest3.idl
@@ -1,5 +1,8 @@
 include "ITest.idl"
 
+/**
+ * ITest3/ITest4 is for checking the single/multiple inheritance of interfaces.
+ */
 interface ITest3 : ITest1 {
     method extra_test3(out uint32 flag);
 };

--- a/tests/idl/ITest3.idl
+++ b/tests/idl/ITest3.idl
@@ -3,3 +3,7 @@ include "ITest.idl"
 interface ITest3 : ITest1 {
     method extra_test3(out uint32 flag);
 };
+
+interface ITest4 : ITest3 {
+    method extra_test4(out uint32 flag);
+};

--- a/tests/src/implementation/test1.rs
+++ b/tests/src/implementation/test1.rs
@@ -5,21 +5,10 @@ use super::{TRUTH, TRUTH2};
 use crate::interfaces::itest::{self, ArrInStruct, SingleEncapsulated, F2, SUCCESS_FLAG};
 use crate::interfaces::itest1::{self, IITest1};
 use crate::interfaces::itest3::{self, IITest3};
+use crate::interfaces::itest4::{self, IITest4};
 
-macro_rules! generate_itest1_impl {
+macro_rules! itest1_impl {
     ($impl: ident) => {
-        #[derive(Debug, Clone, Copy, Default)]
-        pub struct $impl {
-            pub value: u32,
-        }
-
-        impl $impl {
-            #[inline]
-            pub const fn new(value: u32) -> Self {
-                Self { value }
-            }
-        }
-
         impl IITest1 for $impl {
             fn test_f1(&mut self, a: u32) -> Result<u32, itest1::Error> {
                 Ok(self.value + a + 1000)
@@ -246,6 +235,40 @@ macro_rules! generate_itest1_impl {
                 })
             }
         }
+    }
+}
+
+macro_rules! generate_itest1_impl {
+    ($impl: ident) => {
+        #[derive(Debug, Clone, Copy, Default)]
+        pub struct $impl {
+            pub value: u32,
+        }
+
+        impl $impl {
+            #[inline]
+            pub const fn new(value: u32) -> Self {
+                Self { value }
+            }
+        }
+
+        itest1_impl!($impl);
+    };
+}
+
+macro_rules! generate_itest3_impl {
+    ($impl: ident) => {
+        #[derive(Debug, Clone, Copy, Default)]
+        pub struct $impl {
+            pub value: u32,
+        }
+
+        itest1_impl!($impl);
+        impl IITest3 for $impl {
+            fn extra_test3(&mut self) -> Result<u32, itest3::Error> {
+                Ok(SUCCESS_FLAG)
+            }
+        }
     };
 }
 
@@ -254,6 +277,13 @@ generate_itest1_impl!(ITest1);
 generate_itest1_impl!(ITest3);
 impl IITest3 for ITest3 {
     fn r#extra_test3(&mut self) -> Result<u32, itest3::Error> {
+        Ok(SUCCESS_FLAG)
+    }
+}
+
+generate_itest3_impl!(ITest4);
+impl IITest4 for ITest4 {
+    fn r#extra_test4(&mut self) -> Result<u32, itest4::Error> {
         Ok(SUCCESS_FLAG)
     }
 }

--- a/tests/src/lib.rs
+++ b/tests/src/lib.rs
@@ -23,6 +23,9 @@ pub mod interfaces {
     pub mod itest3 {
         include!(concat!(env!("OUT_DIR"), "/rust/itest3.rs"));
     }
+    pub mod itest4 {
+        include!(concat!(env!("OUT_DIR"), "/rust/itest4.rs"));
+    }
 }
 
 pub mod implementation;
@@ -35,6 +38,9 @@ pub mod c {
 
         #[link_name = "create_c_itest2"]
         pub fn create_itest2() -> Option<crate::interfaces::itest2::ITest2>;
+
+        #[link_name = "create_c_itest3"]
+        pub fn create_itest3() -> Option<crate::interfaces::itest3::ITest3>;
     }
 }
 
@@ -46,5 +52,8 @@ pub mod cpp {
 
         #[link_name = "create_cpp_itest2"]
         pub fn create_itest2() -> Option<crate::interfaces::itest2::ITest2>;
+
+        #[link_name = "create_cpp_itest3"]
+        pub fn create_itest3() -> Option<crate::interfaces::itest3::ITest3>;
     }
 }

--- a/tests/src/object/mod.rs
+++ b/tests/src/object/mod.rs
@@ -233,7 +233,7 @@ impl Object {
     ///
     /// # Do not use in application code, this is a minkidl intrinsic.
     fn get_raw_context(&self, invoke: Invoke) -> Option<Ctx> {
-        if self.invoke != invoke || self.context.is_null() {
+        if !std::ptr::fn_addr_eq(self.invoke, invoke) || self.context.is_null() {
             None
         } else {
             Some(self.context)

--- a/tests/tests/c.rs
+++ b/tests/tests/c.rs
@@ -4,7 +4,7 @@
 #![cfg(not(miri))]
 
 use idlc_test::{
-    c::{create_itest1, create_itest2},
+    c::{create_itest1, create_itest2, create_itest3},
     implementation,
     interfaces::itest2::ITest2,
 };
@@ -14,6 +14,8 @@ fn implementation() {
     let c_wrapper = unsafe { create_itest2().unwrap() };
     let input = implementation::ITest1::default().into();
     assert_eq!(c_wrapper.entrypoint(Some(&input)), Ok(()));
+    let c_wrapper_itest3 = unsafe { create_itest3().unwrap() };
+    assert_eq!(c_wrapper_itest3.single_in(0xdead), Ok(()));
 }
 
 #[test]

--- a/tests/tests/cpp.rs
+++ b/tests/tests/cpp.rs
@@ -4,7 +4,7 @@
 #![cfg(not(miri))]
 
 use idlc_test::{
-    cpp::{create_itest1, create_itest2},
+    cpp::{create_itest1, create_itest2, create_itest3},
     implementation,
     interfaces::itest2::ITest2,
 };
@@ -14,6 +14,8 @@ fn implementation() {
     let cpp_wrapper = unsafe { create_itest2().unwrap() };
     let input = implementation::ITest1::default().into();
     assert_eq!(cpp_wrapper.entrypoint(Some(&input)), Ok(()));
+    let cpp_wrapper_itest3 = unsafe { create_itest3().unwrap() };
+    assert_eq!(cpp_wrapper_itest3.single_in(0xdead), Ok(()));
 }
 
 #[test]


### PR DESCRIPTION
- changing C++ impl from const to constexpr (clang++ throws an error when compiling GTEST)

- multiple inheritance is broken. we need a public before each class and a , separator