### PR TITLE
Fixes for 1.91

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -27,6 +27,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
+    - run: rustc -V
     - run: cargo fmt -- --check
 
   lint_check:
@@ -35,6 +36,7 @@ jobs:
     needs: format
     steps:
     - uses: actions/checkout@v4
+    - run: rustc -V
     - run: cargo clippy --all-targets -- -D clippy::all -D unused -D warnings
 
   build:

--- a/idlc_ast_passes/src/idl_store.rs
+++ b/idlc_ast_passes/src/idl_store.rs
@@ -70,6 +70,12 @@ impl CompilerPass<'_> for IDLStore {
     }
 }
 
+impl Default for IDLStore {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl IDLStore {
     /// takes the vector of include paths as an argument which will be saved in `include_paths` field
     #[must_use]

--- a/idlc_codegen/src/counts.rs
+++ b/idlc_codegen/src/counts.rs
@@ -99,15 +99,11 @@ impl Counter {
         let mut me = Self::default();
         super::functions::visit_params(function, &mut me);
 
-        me.input_buffers += if me.has_bundled_input {
-            1
-        } else {
-            Default::default()
+        if me.has_bundled_input {
+            me.input_buffers += 1
         };
-        me.output_buffers += if me.has_bundled_output {
-            1
-        } else {
-            Default::default()
+        if me.has_bundled_output {
+            me.output_buffers += 1
         };
 
         me

--- a/idlc_codegen/src/counts.rs
+++ b/idlc_codegen/src/counts.rs
@@ -99,8 +99,16 @@ impl Counter {
         let mut me = Self::default();
         super::functions::visit_params(function, &mut me);
 
-        me.input_buffers += if me.has_bundled_input { 1 } else { Default::default() };
-        me.output_buffers += if me.has_bundled_output { 1 } else { Default::default() };
+        me.input_buffers += if me.has_bundled_input {
+            1
+        } else {
+            Default::default()
+        };
+        me.output_buffers += if me.has_bundled_output {
+            1
+        } else {
+            Default::default()
+        };
 
         me
     }

--- a/idlc_codegen/src/counts.rs
+++ b/idlc_codegen/src/counts.rs
@@ -99,8 +99,8 @@ impl Counter {
         let mut me = Self::default();
         super::functions::visit_params(function, &mut me);
 
-        me.input_buffers += me.has_bundled_input.then_some(1).unwrap_or_default();
-        me.output_buffers += me.has_bundled_output.then_some(1).unwrap_or_default();
+        me.input_buffers += if me.has_bundled_input { 1 } else { Default::default() };
+        me.output_buffers += if me.has_bundled_output { 1 } else { Default::default() };
 
         me
     }

--- a/idlc_mir/src/mir.rs
+++ b/idlc_mir/src/mir.rs
@@ -696,7 +696,7 @@ impl<'a> Iterator for InterfaceIterator<'a> {
 impl Interface {
     #[inline]
     #[must_use]
-    pub const fn iter(&self) -> InterfaceIterator {
+    pub const fn iter(&self) -> InterfaceIterator<'_> {
         InterfaceIterator {
             interface: Some(self),
         }


### PR DESCRIPTION
Take clippy's suggestions for the latest stable version and also print the rustc version before running the jobs to help make it clear that the problem is with a newer rustc version and not with the PR changes.