### PR TITLE
Method versioning

### DIFF
--- a/idlc/src/cli.rs
+++ b/idlc/src/cli.rs
@@ -1,6 +1,8 @@
 // Copyright (c) 2024, Qualcomm Innovation Center, Inc. All rights reserved.
 // SPDX-License-Identifier: BSD-3-Clause
 
+use idlc_mir::NamedVersion;
+
 fn long_version() -> &'static str {
     let git_hash = env!("GIT_HASH");
 
@@ -81,6 +83,17 @@ pub struct Cli {
     /// This is for compatibility with headers that were generated with a buggy
     /// compiler.
     pub bundle_params_by_size: bool,
+
+    #[arg(long, value_name = "NAME{@|:|=}X.Y", value_parser = clap::value_parser!(NamedVersion))]
+    /// Repeatable: NAME@X.Y | NAME:X.Y | NAME=X.Y
+    ///
+    /// Restrict the list of methods to those found up to - and including - the
+    /// specified interface version. Specifying a version which exceeds the
+    /// interface definition is effectively ignored.
+    ///
+    /// If a spec does not match any interface in the input file, an error is
+    /// thrown. Interface names are case-sensitive.
+    pub spec: Vec<NamedVersion>,
 }
 
 #[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, clap::ValueEnum)]

--- a/idlc/src/lib.rs
+++ b/idlc/src/lib.rs
@@ -21,7 +21,7 @@ use errors::check;
 use idlc_ast::Ast;
 use idlc_ast_passes::{cycles, idl_store::IDLStore, struct_verifier, CompilerPass};
 use idlc_codegen::{Generator, SplitInvokeGenerator};
-use idlc_mir::Mir;
+use idlc_mir::{Mir, NamedVersion};
 use idlc_mir_passes::{interface_verifier, MirCompilerPass};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -109,8 +109,20 @@ impl Compiler {
         mir
     }
 
-    pub fn generate(&self, legal_marking: String, skeleton: bool, no_typed_objects: bool) {
-        let mir = self.parse_to_mir();
+    pub fn generate(
+        &self,
+        legal_marking: String,
+        skeleton: bool,
+        no_typed_objects: bool,
+        specs: Vec<NamedVersion>,
+    ) {
+        let mut mir = self.parse_to_mir();
+
+        // Prune the MIR to specs passed through the CLI, if any. Because the same
+        // mir tree is parsed in multiple places after this, it is easier to modify
+        // the tree itself rather than instruct all code generators to ignore the
+        // same methods.
+        mir.prune(specs);
 
         match self.lang {
             Language::C => {

--- a/idlc/src/main.rs
+++ b/idlc/src/main.rs
@@ -50,6 +50,6 @@ fn main() {
         Some(cli::Dumpable::Pst) => compiler.dump_pst(),
         Some(cli::Dumpable::Ast) => compiler.dump_ast(),
         Some(cli::Dumpable::Mir) => compiler.dump_mir(),
-        _ => compiler.generate(marking, args.skel, args.no_typed_objects),
+        _ => compiler.generate(marking, args.skel, args.no_typed_objects, args.spec),
     }
 }

--- a/idlc_ast/src/ast.rs
+++ b/idlc_ast/src/ast.rs
@@ -1,12 +1,14 @@
 // Copyright (c) 2024, Qualcomm Innovation Center, Inc. All rights reserved.
 // SPDX-License-Identifier: BSD-3-Clause
 
-use std::{num::NonZeroU16, path::PathBuf, rc::Rc};
+use std::{num::NonZeroU16, path::PathBuf, rc::Rc, str::FromStr};
 
 use crate::Error;
 
 /// Maximum allowed size for a struct array [`u16::MAX`]
 pub type Count = NonZeroU16;
+/// Any method which is not explicitly versioned will have an assumed value of 1.0
+pub const DEFAULT_VERSION: APIVersion = APIVersion { major: 1, minor: 0 };
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 /// AST structure for an IDL.
@@ -103,9 +105,80 @@ pub enum InterfaceNode {
     Error(Ident),
 }
 
+// The #[derive(Ord)] produces a lexicographic ordering based on the
+// top-to-bottom declaration order of the struct’s members.
+// 1. Compare major
+// 2. If major is equal, compare minor
+// 3. If both are equal, the values are equal
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub struct APIVersion {
+    pub major: u16,
+    pub minor: u16,
+    // patch is not supported at this time
+}
+impl APIVersion {
+    // Field widths
+    pub const MAJOR_BITS: u32 = 10;
+    pub const MINOR_BITS: u32 = 10;
+    pub const PATCH_BITS: u32 = 12;
+
+    // Masks (unshifted)
+    pub const MAJOR_MASK: u32 = (1u32 << Self::MAJOR_BITS) - 1; // 0x3FF
+    pub const MINOR_MASK: u32 = (1u32 << Self::MINOR_BITS) - 1; // 0x3FF
+    pub const PATCH_MASK: u32 = (1u32 << Self::PATCH_BITS) - 1; // 0xFFF
+}
+
+impl std::fmt::Display for APIVersion {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}.{}", self.major, self.minor)
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum VersionParseError {
+    BadFormat,
+    BadMajor,
+    BadMinor,
+}
+
+impl std::fmt::Display for VersionParseError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            VersionParseError::BadFormat => write!(f, "expected format X.Y (e.g. 1.2)"),
+            VersionParseError::BadMajor => {
+                write!(f, "major version must be an integer in 0..=1023")
+            }
+            VersionParseError::BadMinor => {
+                write!(f, "minor version must be an integer in 0..=1023")
+            }
+        }
+    }
+}
+
+impl std::error::Error for VersionParseError {}
+
+impl FromStr for APIVersion {
+    type Err = VersionParseError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let (maj, min) = s.split_once('.').ok_or(VersionParseError::BadFormat)?;
+        let major: u16 = maj.parse().map_err(|_| VersionParseError::BadMajor)?;
+        let minor: u16 = min.parse().map_err(|_| VersionParseError::BadMinor)?;
+        if (major as u32) > Self::MAJOR_MASK {
+            return Err(VersionParseError::BadMajor);
+        };
+        if (minor as u32) > Self::MINOR_MASK {
+            return Err(VersionParseError::BadMinor);
+        };
+        // patch is not supported at this time
+        Ok(APIVersion { major, minor })
+    }
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum FunctionAttribute {
     Optional,
+    Version(APIVersion),
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/idlc_ast/src/idl_grammar.pest
+++ b/idlc_ast/src/idl_grammar.pest
@@ -25,7 +25,9 @@ struct         =  { struct_keyword ~ (!"interface" ~ ident) ~ "{" ~ (struct_fiel
 const_keyword = @{ "const" ~ WHITESPACE }
 const         =  { const_keyword ~ primitive_type ~ ident ~ "=" ~ value ~ ";" }
 
-supported_attributes = @{ "optional" }
+version              =  { ASCII_DIGIT+ ~ "." ~ ASCII_DIGIT+ }
+method_version       =  { "version" ~ WHITESPACE* ~ "=" ~ WHITESPACE* ~ version }
+supported_attributes =  { "optional" | method_version }
 attribute            = ${ "#[" ~ supported_attributes ~ "]" }
 param_type           =  { ((ident | "interface") ~ bounded_array) | ((primitive_type | !"interface" ~ ident) ~ unbounded_array) | primitive_type | ident | "interface" | "buffer" }
 mutability           = @{ ("in" | "out") }

--- a/idlc_ast/src/pst.rs
+++ b/idlc_ast/src/pst.rs
@@ -11,8 +11,9 @@ use pest_derive::Parser;
 
 // Import all AST types
 use super::ast::{
-    Const, Count, Documentation, Function, FunctionAttribute, Ident, Interface, InterfaceNode,
-    Node, Param, ParamTypeIn, ParamTypeOut, Primitive, Span, Struct, StructField, Type,
+    APIVersion, Const, Count, Documentation, Function, FunctionAttribute, Ident, Interface,
+    InterfaceNode, Node, Param, ParamTypeIn, ParamTypeOut, Primitive, Span, Struct, StructField,
+    Type,
 };
 
 #[derive(thiserror::Error, Debug)]
@@ -133,6 +134,16 @@ impl<'a> From<Pair<'a, Rule>> for FunctionAttribute {
         debug_assert_eq!(attribute.as_rule(), Rule::supported_attributes);
         match attribute.as_str() {
             "optional" => Self::Optional,
+            attr if attr.starts_with("version") => {
+                let method_ver = ast_unwrap!(attribute.into_inner().next());
+                debug_assert_eq!(method_ver.as_rule(), Rule::method_version);
+                let sem_ver = ast_unwrap!(method_ver.into_inner().next());
+                debug_assert_eq!(sem_ver.as_rule(), Rule::version);
+                match sem_ver.as_str().parse::<APIVersion>() {
+                    Ok(ver) => Self::Version(ver),
+                    Err(e) => idlc_errors::unrecoverable!("Error for `{}`: {}", attr, e),
+                }
+            }
             attr => {
                 idlc_errors::unrecoverable!("Unknown function attribute `{attr}`")
             }

--- a/idlc_ast/src/tests/ast.rs
+++ b/idlc_ast/src/tests/ast.rs
@@ -93,4 +93,14 @@ fn duplicately_defined_function_attribute() {
         false,
     )
     .unwrap_err();
+    crate::from_string(
+        std::path::PathBuf::new(),
+        r"interface IFoo {
+        #[version = 1.1]
+        #[version = 1.1]
+        method tmp();
+    };",
+        false,
+    )
+    .unwrap_err();
 }

--- a/idlc_ast/src/tests/parser.rs
+++ b/idlc_ast/src/tests/parser.rs
@@ -174,6 +174,17 @@ fn function() {
             "#[optional] method foo(in buffer req, out buffer rsp);",
             r"#[optional]
               method foo(in buffer req, out buffer rsp);",
+            "#[version = 1.1] method foo(in buffer req, out buffer rsp);",
+            "#[version=1.1] method foo(in buffer req, out buffer rsp);",
+            r"#[version = 1.1]
+              method foo(in buffer req, out buffer rsp);",
+            r"#[version = 1.0]
+              #[version = 1.0]
+              method foo(in buffer req, out buffer rsp);",
+            r"#[version = 1.1000]
+              method foo(in buffer req, out buffer rsp);",
+            r"#[version = 0.0]
+              method foo(in buffer req, out buffer rsp);",
         ]
     );
 
@@ -195,6 +206,11 @@ fn function() {
             "methodfoo();",
             "#[unsupported_attribute] method foo(in buffer req, out buffer rsp);",
             "#[optional]method foo(in buffer req, out buffer rsp);",
+            "#[version = 1.1]method foo(in buffer req, out buffer rsp);",
+            r"#[version = 1]
+              method foo(in buffer req, out buffer rsp);",
+            r"#[version = a.i]
+              method foo(in buffer req, out buffer rsp);",
         ]
     );
 }

--- a/idlc_ast_passes/src/functions.rs
+++ b/idlc_ast_passes/src/functions.rs
@@ -3,7 +3,7 @@
 
 use std::collections::HashSet;
 
-use idlc_ast::{InterfaceNode, Node};
+use idlc_ast::{APIVersion, InterfaceNode, Node, DEFAULT_VERSION};
 
 use crate::CompilerPass;
 
@@ -26,6 +26,8 @@ impl<'ast> CompilerPass<'ast> for Functions {
             Node::Interface(i) => Some(i),
             _ => None,
         }) {
+            // The default version for all functions is 1.0
+            let mut current_version = DEFAULT_VERSION;
             for node in &interface.nodes {
                 if let InterfaceNode::Function(function) = node {
                     let mut params = HashSet::new();
@@ -38,6 +40,45 @@ impl<'ast> CompilerPass<'ast> for Functions {
                                 function.ident,
                                 ident
                             );
+                        }
+                    }
+                    // Check the version of this function
+                    // - Gather any and all listed version attributes
+                    let version_attrs: Vec<&APIVersion> = function
+                        .attributes
+                        .iter()
+                        .filter_map(|attr| match attr {
+                            idlc_ast::FunctionAttribute::Version(a) => Some(a),
+                            _ => None,
+                        })
+                        .collect();
+                    // - Ensure that no more than 1 version is listed
+                    if version_attrs.len() > 1 {
+                        idlc_errors::unrecoverable!(
+                            "Function `{}::{}` has multiple 'version' attributes: {}",
+                            interface.ident,
+                            function.ident,
+                            version_attrs
+                                .iter()
+                                .map(|a| a.to_string())
+                                .collect::<Vec<String>>()
+                                .join(", "),
+                        );
+                    }
+                    // - Ensure that method versions are monotonically increasing
+                    for func_ver in version_attrs {
+                        if func_ver < &current_version {
+                            idlc_errors::unrecoverable!(
+                                "Function `{}::{}` version `{}` cannot be less than the previous method `{}`",
+                                interface.ident,
+                                function.ident,
+                                func_ver,
+                                current_version,
+                            );
+                        }
+                        if func_ver > &current_version {
+                            // Carry the current version forward to the next function
+                            current_version = *func_ver;
                         }
                     }
                 }

--- a/idlc_codegen/src/keywords.rs
+++ b/idlc_codegen/src/keywords.rs
@@ -1,8 +1,13 @@
 // Copyright (c) 2024, Qualcomm Innovation Center, Inc. All rights reserved.
 // SPDX-License-Identifier: BSD-3-Clause
 
+pub mod invoke {
+    // Name of function which gets added to all auto-generated outputs
+    pub const VERSION_FUNC_NAME: &str = "api_version";
+}
+
 macro_rules! keyword_gen {
-    ($($lang: literal: [$($value: literal),*]),*) => {
+    ($($lang: literal: [$($value: expr),*]),*) => {
         &[$($($value,)*)*]
     };
 }
@@ -21,6 +26,7 @@ macro_rules! keyword_gen {
 /// keywords using the `r#` syntax. See
 /// [raw-identifiers](https://doc.rust-lang.org/rust-by-example/compatibility/raw_identifiers.html#raw-identifiers)
 const RESERVED_KEYWORDS: &[&str] = keyword_gen! {
+    "Mink IDL": [invoke::VERSION_FUNC_NAME],
     "C17": [
         "auto", "break", "case", "char", "const", "continue", "default", "do", "double",
         "else", "enum", "extern", "float", "for", "goto", "if", "inline", "int",

--- a/idlc_codegen/src/lib.rs
+++ b/idlc_codegen/src/lib.rs
@@ -9,7 +9,7 @@ pub mod serialization;
 
 // TODO: Remove this when we indeed start banning idents matching reserved keywords
 #[allow(dead_code)]
-mod keywords;
+pub mod keywords;
 
 use std::path::PathBuf;
 

--- a/idlc_codegen_c/src/generator.rs
+++ b/idlc_codegen_c/src/generator.rs
@@ -28,7 +28,7 @@ impl idlc_codegen::SplitInvokeGenerator for Generator {
         result.push_str(&generate_common());
 
         for node in &mir.nodes {
-            match node.as_ref() {
+            match node {
                 Node::Include(i) => {
                     result.push_str(&emit_include(i));
                 }
@@ -54,7 +54,7 @@ impl idlc_codegen::SplitInvokeGenerator for Generator {
         result.push_str(&format!("#include \"{}.h\"\n", input_name));
 
         for node in &mir.nodes {
-            match node.as_ref() {
+            match node {
                 Node::Include(i) => {
                     result.push_str(&emit_include(i));
                 }

--- a/idlc_codegen_c/src/interface/mod.rs
+++ b/idlc_codegen_c/src/interface/mod.rs
@@ -1,7 +1,8 @@
 // Copyright (c) 2024, Qualcomm Innovation Center, Inc. All rights reserved.
 // SPDX-License-Identifier: BSD-3-Clause
 
-use idlc_mir::{Interface, InterfaceNode};
+use idlc_codegen::keywords::invoke::VERSION_FUNC_NAME;
+use idlc_mir::{APIVersion, Interface, InterfaceNode};
 
 pub mod functions;
 pub mod variable_names;
@@ -100,8 +101,17 @@ pub fn emit_interface_impl(interface: &Interface, is_no_typed_objects: bool) -> 
         format!("typedef Object {ident};")
     };
 
+    let interface_version = interface.get_version();
+
     format!(
         r#"
+#define {ident}_MAJOR_MASK  ((uint32_t)0x3FF)  /* 10 bits */
+#define {ident}_MINOR_MASK  ((uint32_t)0x3FF)  /* 10 bits */
+#define {ident}_MAJOR_SHIFT ((uint32_t)22)
+#define {ident}_MINOR_SHIFT ((uint32_t)12)
+#define {ident}_PATCH_MASK  ((uint32_t)0xFFF)  /* 12 bits */
+
+// '{ident}' interface at version '{interface_version}'
 {object_defined}
 {constants}
 {errors}
@@ -116,6 +126,15 @@ static inline int32_t
 {ident}_retain(Object self)
 {{
     return Object_invoke(self, Object_OP_retain, 0, 0);
+}}
+
+static inline int32_t
+{ident}_{VERSION_FUNC_NAME}(Object self, uint32_t *a_ptr)
+{{
+    ObjectArg a[] = {{
+        {{.b = (ObjectBuf) {{ a_ptr, sizeof(uint32_t) }} }},
+    }};
+    return Object_invoke(self, Object_OP_version, a, ObjectCounts_pack(0, 1, 0, 0));
 }}
 {implementations}
 "#
@@ -166,6 +185,8 @@ pub fn emit_interface_invoke(interface: &Interface, is_no_typed_objects: bool) -
         .then_some(format!(r#"typedef Object {ident};"#))
         .unwrap_or_default();
 
+    let APIVersion { major, minor } = interface.get_version();
+
     // weak_delcarations goes inside `func` to preserve the expected when the macro is instantiated
     // with `static IFoo_DEFINE_INVOKE`. It is OK to declare functions within functions for C.
     format!(
@@ -179,6 +200,10 @@ pub fn emit_interface_invoke(interface: &Interface, is_no_typed_objects: bool) -
 #define __compiler_pragma_pre
 #define __compiler_pragma_post
 #endif
+
+#define {ident}_VERSION_MAJOR {major}
+#define {ident}_VERSION_MINOR {minor}
+#define {ident}_VERSION_PATCH 0
 
 #define {ident}_DEFINE_INVOKE(func, prefix, type) \
     int32_t func(ObjectCxt {CONTEXT}, ObjectOp {OP_CODE}, ObjectArg *{ARGS}, ObjectCounts {COUNTS}) \
@@ -199,6 +224,17 @@ pub fn emit_interface_invoke(interface: &Interface, is_no_typed_objects: bool) -
                     break; \
                 }} \
                 return prefix##retain(me); \
+            }} \
+            case Object_OP_version: {{ \
+                if (k != ObjectCounts_pack(0, 1, 0, 0) || a[0].b.size != 4) {{ \
+                  break; \
+                }} \
+                uint32_t *a_ptr = (void*)a[0].b.ptr; \
+                *a_ptr = (({ident}_VERSION_MAJOR & {ident}_MAJOR_MASK) << {ident}_MAJOR_SHIFT) | \
+                         (({ident}_VERSION_MINOR & {ident}_MINOR_MASK) << {ident}_MINOR_SHIFT) | \
+                          ({ident}_VERSION_PATCH & {ident}_PATCH_MASK); \
+                a[0].b.size = sizeof(uint32_t); \
+                return Object_OK; \
             }} \
             {invokes} \
         }} \

--- a/idlc_codegen_cpp/src/generator.rs
+++ b/idlc_codegen_cpp/src/generator.rs
@@ -16,7 +16,7 @@ impl idlc_codegen::SplitInvokeGenerator for Generator {
         result.push_str(&generate_common());
 
         for node in &mir.nodes {
-            match node.as_ref() {
+            match node {
                 Node::Include(i) => {
                     let inc_name = i.display().to_string().replace(".idl", "");
                     result.push_str(&format!("#include \"{}.hpp\"\n", inc_name));
@@ -54,7 +54,7 @@ impl idlc_codegen::SplitInvokeGenerator for Generator {
         ));
 
         for node in &mir.nodes {
-            match node.as_ref() {
+            match node {
                 Node::Include(i) => {
                     let inc_name = i.display().to_string().replace(".idl", "");
                     result.push_str(&format!("#include \"{}.hpp\"\n", inc_name));

--- a/idlc_codegen_cpp/src/interface/mod.rs
+++ b/idlc_codegen_cpp/src/interface/mod.rs
@@ -1,7 +1,8 @@
 // Copyright (c) 2024, Qualcomm Innovation Center, Inc. All rights reserved.
 // SPDX-License-Identifier: BSD-3-Clause
 
-use idlc_mir::{Interface, InterfaceNode};
+use idlc_codegen::keywords::invoke::VERSION_FUNC_NAME;
+use idlc_mir::{APIVersion, Interface, InterfaceNode};
 
 mod functions;
 
@@ -114,11 +115,19 @@ pub fn emit_interface_impl(interface: &Interface) -> String {
         base_iface = format!(": public {first_base_iface} ");
     }
 
+    let interface_version = interface.get_version();
+
     format!(
         r#"
+// '{ident}' interface at version '{interface_version}'
 class {ident};
 class I{ident} {base_iface}{{
   public:{constants}
+    static constexpr uint16_t PATCH_MASK  = 0x0FFF; /* 12 bits */
+    static constexpr uint16_t MINOR_MASK  = 0x03FF; /* 10 bits */
+    static constexpr uint16_t MAJOR_MASK  = 0x03FF; /* 10 bits */
+    static constexpr uint16_t MINOR_SHIFT = UINT8_C(12);
+    static constexpr uint16_t MAJOR_SHIFT = MINOR_SHIFT + UINT8_C(10);
 {errors}
 
     virtual ~I{ident}() {{}}
@@ -133,7 +142,12 @@ class {ident} : public I{ident}, public ProxyBase {{
     {ident}() {{}}
     {ident}(Object impl) : ProxyBase(impl) {{}}
     virtual ~{ident}() {{}}
-
+    virtual int32_t {VERSION_FUNC_NAME}(uint32_t *a_ptr) {{
+        ObjectArg a[] = {{
+            {{.b = (ObjectBuf) {{ a_ptr, sizeof(uint32_t) }} }},
+        }};
+        return invoke(Object_OP_version, a, ObjectCounts_pack(0, 1, 0, 0));
+    }}
 {implementations}
 }};
 
@@ -178,12 +192,23 @@ pub fn emit_interface_invoke(interface: &Interface) -> String {
         }
     }
 
+    let APIVersion { major, minor } = interface.get_version();
+
     format!(
         r#"
 class {ident}ImplBase : protected ImplBase, public I{ident} {{
   public:
     {ident}ImplBase() {{}}
     virtual ~{ident}ImplBase() {{}}
+    static constexpr uint16_t VERSION_MAJOR = UINT16_C({major});
+    static constexpr uint16_t VERSION_MINOR = UINT16_C({minor});
+    static constexpr uint16_t VERSION_PATCH = 0;
+    virtual int32_t {VERSION_FUNC_NAME}(uint32_t *a_ptr) {{
+        *a_ptr = ((VERSION_MAJOR & MAJOR_MASK) << MAJOR_SHIFT) | \
+                 ((VERSION_MINOR & MINOR_MASK) << MINOR_SHIFT) | \
+                  (VERSION_PATCH & PATCH_MASK);
+        return Object_OK;
+    }}
 {weak_declarations}
   protected:
     virtual int32_t invoke(ObjectOp {OP_CODE}, ObjectArg* {ARGS}, ObjectCounts {COUNTS}) {{

--- a/idlc_codegen_java/src/generator.rs
+++ b/idlc_codegen_java/src/generator.rs
@@ -30,7 +30,7 @@ package com.qualcomm.qti.mink;
         let input_name = &mir.tag.file_stem().unwrap().to_str().unwrap();
         let mut includes = String::new();
         for node in &mir.nodes {
-            if let Node::Include(i) = node.as_ref() {
+            if let Node::Include(i) = node {
                 let inc_name = i.display().to_string().replace(".idl", "");
                 includes.push_str(&format!("{inc_name},"));
             }
@@ -45,7 +45,7 @@ package com.qualcomm.qti.mink;
         ));
 
         for node in &mir.nodes {
-            match node.as_ref() {
+            match node {
                 Node::Const(c) => {
                     interfaces.get_mut(&base).unwrap().push_str(&emit_const(c));
                 }

--- a/idlc_codegen_rust/src/generator.rs
+++ b/idlc_codegen_rust/src/generator.rs
@@ -31,7 +31,7 @@ impl idlc_codegen::Generator for Generator {
         interfaces.insert(base.clone(), prologue.to_owned());
 
         for node in &mir.nodes {
-            match node.as_ref() {
+            match node {
                 Node::Const(c) => {
                     interfaces.get_mut(&base).unwrap().push_str(&emit_const(c));
                 }

--- a/idlc_codegen_rust/src/interface/mink_primitives.rs
+++ b/idlc_codegen_rust/src/interface/mink_primitives.rs
@@ -20,6 +20,7 @@ pub(super) const COUNTS: &str = namespace!("Counts");
 
 pub(super) const OP_RELEASE: &str = namespace!("OP_RELEASE");
 pub(super) const OP_RETAIN: &str = namespace!("OP_RETAIN");
+pub(super) const OP_VERSION: &str = namespace!("OP_VERSION");
 
 pub(super) const WRAPPER: &str = namespace!("wrapper");
 

--- a/idlc_codegen_rust/src/interface/mod.rs
+++ b/idlc_codegen_rust/src/interface/mod.rs
@@ -3,7 +3,8 @@
 
 use crate::globals::emit_const;
 
-use idlc_mir::{Interface, InterfaceNode};
+use idlc_codegen::keywords::invoke::VERSION_FUNC_NAME;
+use idlc_mir::{APIVersion, Interface, InterfaceNode};
 
 mod error;
 mod functions;
@@ -13,7 +14,7 @@ mod variable_names;
 pub fn emit(interface: &Interface) -> String {
     use mink_primitives::{
         ARG, CONTEXT, COUNTS, GENERIC_ERROR, INVOKE_FN, OBJECT, OP_ID, OP_RELEASE, OP_RETAIN,
-        TYPED_OBJECT_TRAIT, WRAPPER,
+        OP_VERSION, TYPED_OBJECT_TRAIT, WRAPPER,
     };
     let ident = &interface.ident;
     let mut trait_functions = Vec::new();
@@ -84,6 +85,9 @@ pub fn emit(interface: &Interface) -> String {
 
     let wrapper = format!("{WRAPPER}::Wrapper::<dyn I{ident}>");
 
+    let interface_version = interface.get_version();
+    let APIVersion { major, minor } = interface_version;
+
     let output = format!(
         r#"
     {errors}
@@ -99,7 +103,28 @@ pub fn emit(interface: &Interface) -> String {
         {trait_functions}
     }}
 
+    /// '{ident}' interface at version '{interface_version}'
     impl {ident} {{
+        pub fn r#{VERSION_FUNC_NAME}(&self) -> Result<(u32), Error> {{
+            let mut r#a = std::mem::MaybeUninit::<u32>::uninit();
+            let mut args = [
+                crate::object::Arg {{
+                    bi: crate::object::BufIn {{
+                        ptr: std::ptr::addr_of_mut!(r#a).cast(),
+                        size: std::mem::size_of::<u32>(),
+                    }},
+                }},
+            ];
+            match unsafe {{
+                self.0.invoke({OP_VERSION}, args.as_mut_ptr(), crate::object::pack_counts(0, 1, 0, 0))
+            }} {{
+                0 => {{
+                    let r#a = unsafe {{ r#a.assume_init() }};
+                    Ok((r#a))
+                }}
+                err => Err(unsafe {{ std::mem::transmute(err) }}),
+            }}
+        }}
         {implementations}
     }}
 
@@ -144,8 +169,113 @@ pub fn emit(interface: &Interface) -> String {
             {OP_RETAIN} => {{
                 {WRAPPER}::retain(cx)
             }},
+            {OP_VERSION} => {{
+                if counts != crate::object::pack_counts(0, 1, 0, 0) {{
+                    return std::mem::transmute(crate::object::error::generic::GENERIC);
+                }}
+                let args = std::slice::from_raw_parts_mut(args, 1);
+                let r#a_orig = args[0].b.size;
+                if r#a_orig < std::mem::size_of::<u32>() {{
+                    return {GENERIC_ERROR}::SIZE_OUT.into();
+                }}
+                let r#a_lenout = &mut *std::ptr::addr_of_mut!(args[0].b.size);
+                let r#a = std::slice::from_raw_parts_mut(
+                    args[0].b.ptr.cast::<u8>(),
+                    r#a_orig / std::mem::size_of::<u8>(),
+                );
+                let value: u32 = IDLVersion::new({major}, {minor}, 0).into();
+                r#a.copy_from_slice(&value.to_le_bytes());
+                *r#a_lenout = std::mem::size_of::<u32>();
+                0
+            }},
             _ => {GENERIC_ERROR}::INVALID.into(),
         }}
+    }}
+
+    #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Debug, Default)]
+    #[repr(transparent)]
+    pub struct IDLVersion(u32);
+
+    impl IDLVersion {{
+        // Field widths
+        pub const MAJOR_BITS: u32 = 10;
+        pub const MINOR_BITS: u32 = 10;
+        pub const PATCH_BITS: u32 = 12;
+
+        // Bit positions (LSB = bit 0)
+        pub const PATCH_SHIFT: u32 = 0;
+        pub const MINOR_SHIFT: u32 = Self::PATCH_SHIFT + Self::PATCH_BITS; // 12
+        pub const MAJOR_SHIFT: u32 = Self::MINOR_SHIFT + Self::MINOR_BITS; // 22
+
+        // Masks (unshifted)
+        pub const MAJOR_MASK: u32 = (1u32 << Self::MAJOR_BITS) - 1; // 0x3FF
+        pub const MINOR_MASK: u32 = (1u32 << Self::MINOR_BITS) - 1; // 0x3FF
+        pub const PATCH_MASK: u32 = (1u32 << Self::PATCH_BITS) - 1; // 0xFFF
+
+        /// Pack (major, minor, patch) into a single u32.
+        /// Values are truncated to their field widths.
+        pub const fn new(major: u16, minor: u16, patch: u16) -> Self {{
+            let major = (major as u32) & Self::MAJOR_MASK;
+            let minor = (minor as u32) & Self::MINOR_MASK;
+            let patch = (patch as u32) & Self::PATCH_MASK;
+
+            Self((major << Self::MAJOR_SHIFT) |
+                 (minor << Self::MINOR_SHIFT) |
+                 (patch << Self::PATCH_SHIFT))
+        }}
+
+        /// Like `new`, but returns None if any component is out of range.
+        pub const fn try_new(major: u16, minor: u16, patch: u16) -> Option<Self> {{
+            if (major as u32) > Self::MAJOR_MASK {{ return None; }}
+            if (minor as u32) > Self::MINOR_MASK {{ return None; }}
+            if (patch as u32) > Self::PATCH_MASK {{ return None; }}
+            Some(Self::new(major, minor, patch))
+        }}
+
+        #[inline(always)]
+        pub const fn major(self) -> u16 {{
+            (((self.0 >> Self::MAJOR_SHIFT) & Self::MAJOR_MASK) as u16)
+        }}
+
+        #[inline(always)]
+        pub const fn minor(self) -> u16 {{
+            (((self.0 >> Self::MINOR_SHIFT) & Self::MINOR_MASK) as u16)
+        }}
+
+        #[inline(always)]
+        pub const fn patch(self) -> u16 {{
+            (((self.0 >> Self::PATCH_SHIFT) & Self::PATCH_MASK) as u16)
+        }}
+
+        /// Access the raw packed value (host endianness).
+        #[inline(always)]
+        pub const fn as_u32(self) -> u32 {{
+            self.0
+        }}
+
+        /// Construct from a raw packed value (host endianness).
+        #[inline(always)]
+        pub const fn from_u32(raw: u32) -> Self {{
+            Self(raw)
+        }}
+
+        #[inline(always)]
+        pub const fn to_le_bytes(self) -> [u8; 4] {{
+            self.0.to_le_bytes()
+        }}
+
+        #[inline(always)]
+        pub const fn from_le_bytes(bytes: [u8; 4]) -> Self {{
+            Self(u32::from_le_bytes(bytes))
+        }}
+    }}
+
+    // Optional ergonomic conversions:
+    impl From<u32> for IDLVersion {{
+        fn from(v: u32) -> Self {{ Self(v) }}
+    }}
+    impl From<IDLVersion> for u32 {{
+        fn from(v: IDLVersion) -> u32 {{ v.0 }}
     }}
 
     /// Downcasts to the value of type `T` that was used to create this object.

--- a/idlc_mir/Cargo.toml
+++ b/idlc_mir/Cargo.toml
@@ -8,6 +8,8 @@ edition = "2021"
 [dependencies]
 idlc_ast = { path = "../idlc_ast" }
 idlc_ast_passes = { path="../idlc_ast_passes" }
+idlc_errors = {path = "../idlc_errors" }
+thiserror = '1.0.59'
 
 [package.metadata.workspaces]
 independent = true

--- a/idlc_mir/src/lib.rs
+++ b/idlc_mir/src/lib.rs
@@ -2,6 +2,8 @@
 // SPDX-License-Identifier: BSD-3-Clause
 
 pub mod mir;
+pub mod named_version;
 
 pub use idlc_ast::pst::Error;
 pub use mir::*;
+pub use named_version::*;

--- a/idlc_mir/src/mir.rs
+++ b/idlc_mir/src/mir.rs
@@ -25,7 +25,7 @@
 //! codegens from AST changes; AST changes tomorrow which don't require MIR
 //! changes should not require codegen changes
 use idlc_ast::Ast;
-pub use idlc_ast::Ident;
+pub use idlc_ast::{APIVersion, Ident, DEFAULT_VERSION};
 use idlc_ast_passes::idl_store::IDLStore;
 
 use std::collections::{HashMap, VecDeque};
@@ -249,6 +249,21 @@ pub struct Interface {
     pub nodes: Vec<InterfaceNode>,
 }
 
+impl Interface {
+    // Determine the overall version of the IDL by finding the max version
+    // attribute among all functions.
+    pub fn get_version(&self) -> &APIVersion {
+        self.nodes
+            .iter()
+            .filter_map(|n| match n {
+                InterfaceNode::Function(func) => func.get_version(),
+                _ => None,
+            })
+            .max()
+            .unwrap_or(&DEFAULT_VERSION)
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum InterfaceNode {
     Const(Const),
@@ -446,6 +461,12 @@ impl Function {
     pub fn is_optional(&self) -> bool {
         self.attributes
             .contains(&idlc_ast::FunctionAttribute::Optional)
+    }
+    pub fn get_version(&self) -> Option<&APIVersion> {
+        self.attributes.iter().find_map(|e| match e {
+            idlc_ast::FunctionAttribute::Version(a) => Some(a),
+            _ => None,
+        })
     }
 }
 

--- a/idlc_mir/src/mir.rs
+++ b/idlc_mir/src/mir.rs
@@ -24,6 +24,7 @@
 //! directly depending on AST and for MIR to produce an interface to shield
 //! codegens from AST changes; AST changes tomorrow which don't require MIR
 //! changes should not require codegen changes
+use crate::named_version::NamedVersion;
 use idlc_ast::Ast;
 pub use idlc_ast::{APIVersion, Ident, DEFAULT_VERSION};
 use idlc_ast_passes::idl_store::IDLStore;
@@ -45,7 +46,7 @@ pub struct Mir {
     /// This doesn't have to be unique.
     pub tag: PathBuf,
     /// Root node for the [`Mir`] tree.
-    pub nodes: Vec<Rc<Node>>,
+    pub nodes: Vec<Node>,
 }
 
 #[derive(Debug, Clone, PartialEq)]
@@ -476,15 +477,15 @@ pub struct Error {
     pub value: i32,
 }
 
-fn parse_include(path: &Path) -> Rc<Node> {
-    Rc::new(Node::Include(path.to_path_buf()))
+fn parse_include(path: &Path) -> Node {
+    Node::Include(path.to_path_buf())
 }
 
-fn parse_const(const_: &idlc_ast::Const) -> Rc<Node> {
-    Rc::new(Node::Const(Const::from(const_)))
+fn parse_const(const_: &idlc_ast::Const) -> Node {
+    Node::Const(Const::from(const_))
 }
 
-fn parse_struct(struct_: &idlc_ast::Struct, idl_store: &IDLStore) -> Rc<Node> {
+fn parse_struct(struct_: &idlc_ast::Struct, idl_store: &IDLStore) -> Node {
     let ident = struct_.ident.clone();
     let mut fields = Vec::<StructField>::new();
     let mut size = 0;
@@ -498,14 +499,14 @@ fn parse_struct(struct_: &idlc_ast::Struct, idl_store: &IDLStore) -> Rc<Node> {
         fields.push(field);
     }
 
-    Rc::new(Node::Struct(Struct::new(
+    Node::Struct(Struct::new(
         StructInner {
             ident,
             fields,
             origin: None,
         },
         size,
-    )))
+    ))
 }
 
 fn parse_interface(
@@ -587,12 +588,12 @@ pub fn parse_to_mir(ast: &Ast, idl_store: &mut IDLStore) -> Mir {
             idlc_ast::Node::Interface(interface) => {
                 let mut err_code = ERROR_CODE_START;
                 let mut op_code = 0;
-                nodes.push(Rc::new(Node::Interface(parse_interface(
+                nodes.push(Node::Interface(parse_interface(
                     interface,
                     idl_store,
                     &mut err_code,
                     &mut op_code,
-                ))));
+                )));
             }
         }
     }
@@ -600,6 +601,30 @@ pub fn parse_to_mir(ast: &Ast, idl_store: &mut IDLStore) -> Mir {
     Mir {
         tag: ast.tag.clone(),
         nodes,
+    }
+}
+
+impl Mir {
+    /// Prune any methods which are above the corresponding version
+    pub fn prune(&mut self, specs: Vec<NamedVersion>) {
+        for spec in specs {
+            let NamedVersion { name, version } = spec;
+            // Find the interface whose name matches the targeted version, if it exists
+            if let Some(interface) = self.nodes.iter_mut().find_map(|node| match node {
+                Node::Interface(i_face) if i_face.ident.ident == name => Some(i_face),
+                _ => None,
+            }) {
+                // If the function version is greater than the targeted version, prune it.
+                if version < *interface.get_version() {
+                    interface.nodes.retain(|x| match x {
+                        InterfaceNode::Function(f) => f.get_version().is_none_or(|v| *v <= version),
+                        _ => true,
+                    });
+                }
+            } else {
+                idlc_errors::error!("Spec `{}` was not found in {}", name, self.tag.display());
+            }
+        }
     }
 }
 

--- a/idlc_mir/src/named_version.rs
+++ b/idlc_mir/src/named_version.rs
@@ -1,0 +1,55 @@
+use idlc_ast::{APIVersion, VersionParseError};
+use std::str::FromStr;
+use thiserror::Error;
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct NamedVersion {
+    pub name: String,
+    pub version: APIVersion,
+}
+
+#[derive(Debug, Error)]
+pub enum ParseError {
+    #[error("expected NAME@X.Y, NAME:X.Y, or NAME=X.Y (e.g. api@1.2)")]
+    MissingSeparator,
+    #[error("missing name before the separator (e.g. api@1.2)")]
+    MissingName,
+    #[error("missing version after the separator (e.g. api@1.2)")]
+    MissingVersion,
+    #[error("{0}")]
+    Version(#[from] VersionParseError),
+}
+
+impl FromStr for NamedVersion {
+    type Err = ParseError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let s = s.trim();
+
+        // Find the first separator occurrence among '@', ':', '='
+        let (idx, _sep) = s
+            .char_indices()
+            .find(|&(_, c)| c == '@' || c == ':' || c == '=')
+            .ok_or(ParseError::MissingSeparator)?;
+
+        let (name, ver) = s.split_at(idx);
+        let ver = &ver[1..]; // drop the separator char
+
+        let name = name.trim();
+        let ver = ver.trim();
+
+        if name.is_empty() {
+            return Err(ParseError::MissingName);
+        }
+        if ver.is_empty() {
+            return Err(ParseError::MissingVersion);
+        }
+
+        let version = ver.parse::<APIVersion>()?;
+
+        Ok(NamedVersion {
+            name: name.to_owned(),
+            version,
+        })
+    }
+}

--- a/idlc_mir/tests/mir.rs
+++ b/idlc_mir/tests/mir.rs
@@ -53,7 +53,7 @@ fn op_code_test() {
             };
         ",
     );
-    let node = &**mir.nodes.last().unwrap();
+    let node = mir.nodes.last().unwrap();
     let mut out: Vec<(&str, u32)> = vec![];
     if let idlc_mir::Node::Interface(interface) = node {
         let fn_iterator = interface.iter().flat_map(|iface| {
@@ -111,7 +111,7 @@ fn err_code_test() {
             };
         ",
     );
-    let node = &**mir.nodes.last().unwrap();
+    let node = mir.nodes.last().unwrap();
     let mut out: Vec<(&str, i32)> = vec![];
     if let idlc_mir::Node::Interface(interface) = node {
         let fn_iterator = interface.iter().flat_map(|iface| {

--- a/idlc_mir_passes/src/interface_verifier.rs
+++ b/idlc_mir_passes/src/interface_verifier.rs
@@ -23,7 +23,7 @@ impl MirCompilerPass<'_> for InterfaceVerifier<'_> {
 
     fn run_pass(&'_ mut self) -> Self::Output {
         for src in self.mir.nodes.iter().filter_map(|x| {
-            if let Node::Interface(src) = x.as_ref() {
+            if let Node::Interface(src) = x {
                 Some(src)
             } else {
                 None

--- a/tests/c/invoke.c
+++ b/tests/c/invoke.c
@@ -59,6 +59,17 @@ int32_t test_singular_object(Object itest1) {
     CHECK_OK(ITest1_well_documented_method(itest1, SUCCESS_FLAG, &out));
     ASSERT(out == SUCCESS_FLAG);
   }
+  {
+    // Check for version against typed and generic Objects
+    uint32_t version = 0;
+    CHECK_OK(ITest1_api_version(itest1, &version));
+    uint32_t major = (version >> ITest1_MAJOR_SHIFT) & ITest1_MAJOR_MASK;
+    uint32_t minor = (version >> ITest1_MINOR_SHIFT) & ITest1_MINOR_MASK;
+    uint32_t patch =  version                        & ITest1_PATCH_MASK;
+    ASSERT(major == 2);
+    ASSERT(minor == 0);
+    ASSERT(patch == 0);
+  }
 
   return Object_OK;
 }
@@ -248,6 +259,27 @@ int32_t itest1_objects_in_struct(struct CTest1 *ctx, const ObjInStruct *input,
   output->second_obj = create_c_itest1(2);
   output->should_be_empty = Object_NULL;
 
+  return Object_OK;
+}
+
+int32_t itest1_derive_v0(struct CTest1 *ctx, uint32_t a_val) {
+  return Object_OK;
+}
+
+int32_t itest1_derive_v1(struct CTest1 *ctx, uint32_t a_val) {
+  return Object_OK;
+}
+
+int32_t itest1_derive_v2(struct CTest1 *ctx, uint32_t a_val) {
+  return Object_OK;
+}
+
+int32_t itest1_derive_v255(struct CTest1 *ctx, uint32_t *output_ptr) {
+  *output_ptr = 0xdead;
+  return Object_OK;
+}
+
+int32_t itest1_derive_v2p2(struct CTest1 *ctx, uint32_t a_val) {
   return Object_OK;
 }
 
@@ -443,6 +475,27 @@ int32_t itest3_objects_in_struct(struct CTest1 *ctx, const ObjInStruct *input,
   return itest1_objects_in_struct(ctx, input, output);
 }
 
-ITest3_DEFINE_INVOKE(itest3_invoke, itest3_, void *);
+int32_t itest3_derive_v0(struct CTest1 *ctx, uint32_t a_val) {
+  return Object_OK;
+}
+
+int32_t itest3_derive_v1(struct CTest1 *ctx, uint32_t a_val) {
+  return Object_OK;
+}
+
+int32_t itest3_derive_v2(struct CTest1 *ctx, uint32_t a_val) {
+  return Object_OK;
+}
+
+int32_t itest3_derive_v255(struct CTest1 *ctx, uint32_t *output_ptr) {
+  *output_ptr = 0xdead;
+  return Object_OK;
+}
+
+int32_t itest3_derive_v2p2(struct CTest1 *ctx, uint32_t a_val) {
+  return Object_OK;
+}
+
+ITest3_DEFINE_INVOKE(itest3_invoke, itest3_, struct CTest1 *);
 
 Object create_c_itest3() { return (Object){itest3_invoke, NULL}; }

--- a/tests/c/object.h
+++ b/tests/c/object.h
@@ -223,6 +223,7 @@ static inline int32_t Object_invoke(Object o, ObjectOp op, ObjectArg *args, Obje
 
 #define Object_OP_release       (ObjectOp_METHOD_MASK - 0U)
 #define Object_OP_retain        (ObjectOp_METHOD_MASK - 1U)
+#define Object_OP_version       (ObjectOp_LOCAL - 1)
 
 #define Object_release(o)       Object_invoke((o), Object_OP_release, 0, 0)
 #define Object_retain(o)        Object_invoke((o), Object_OP_retain, 0, 0)

--- a/tests/cpp/impl_base.hpp
+++ b/tests/cpp/impl_base.hpp
@@ -37,6 +37,13 @@ class ImplBase {
                 me->retain();
                 return Object_OK;
             }
+            case Object_OP_version: {
+                if (arg_count != ObjectCounts_pack(0, 1, 0, 0) || args[0].b.size != 4) {
+                    return Object_ERROR_INVALID;
+                }
+                uint32_t *a_ptr = (uint32_t*)args[0].b.ptr;
+                return me->api_version(a_ptr);
+            }
             default:
                 return me->invoke(op, args, arg_count);
         }
@@ -56,6 +63,11 @@ class ImplBase {
         auto old_value = refcount--;
         assert(old_value > 0);
         return old_value == 1;
+    }
+
+    // Auto-generated classes override this function
+    virtual int32_t api_version(uint32_t *a_ptr) {
+      return Object_ERROR_INVALID;
     }
 
    private:

--- a/tests/cpp/main.cpp
+++ b/tests/cpp/main.cpp
@@ -153,6 +153,23 @@ public:
     return Object_OK;
   }
 
+  int32_t derive_v0(uint32_t a_val) {
+    return Object_OK;
+  }
+  int32_t derive_v1(uint32_t a_val) {
+    return Object_OK;
+  }
+  int32_t derive_v2(uint32_t a_val) {
+    return Object_OK;
+  }
+  int32_t derive_v255(uint32_t *output_ptr) {
+    *output_ptr = 0xdead;
+    return Object_OK;
+  }
+  int32_t derive_v2p2(uint32_t a_val) {
+    return Object_OK;
+  }
+
 private:
   struct c::CTest1 ctest;
 };
@@ -224,6 +241,15 @@ public:
     Object_ASSIGN_NULL(output_struct.should_be_empty);
 
     ASSERT(me.unimplemented(3) == Object_ERROR_INVALID);
+
+    uint32_t version = 0;
+    CHECK_OK(me.api_version(&version));
+    uint32_t major = (version >> ITest1::MAJOR_SHIFT) & ITest1::MAJOR_MASK;
+    uint32_t minor = (version >> ITest1::MINOR_SHIFT) & ITest1::MINOR_MASK;
+    uint32_t patch =  version                         & ITest1::PATCH_MASK;
+    ASSERT(major == 2);
+    ASSERT(minor == 0);
+    ASSERT(patch == 0);
 
     return Object_OK;
   }
@@ -369,6 +395,22 @@ public:
     output_ref.first_obj = create_cpp_itest1(1);
     output_ref.second_obj = create_cpp_itest1(2);
     output_ref.should_be_empty = Object_NULL;
+    return Object_OK;
+  }
+  int32_t derive_v0(uint32_t a_val) {
+    return Object_OK;
+  }
+  int32_t derive_v1(uint32_t a_val) {
+    return Object_OK;
+  }
+  int32_t derive_v2(uint32_t a_val) {
+    return Object_OK;
+  }
+  int32_t derive_v255(uint32_t *output_ptr) {
+    *output_ptr = 0xdead;
+    return Object_OK;
+  }
+  int32_t derive_v2p2(uint32_t a_val) {
     return Object_OK;
   }
 private:

--- a/tests/idl/ITest.idl
+++ b/tests/idl/ITest.idl
@@ -66,6 +66,17 @@ interface ITest1 {
   method objects_in_struct(in ObjInStruct input, out ObjInStruct output);
   #[optional]
   method unimplemented(in uint32 foo); // this method should NOT have an implementation and that is OK
+
+  #[version = 1.0]
+  method derive_v0(in uint32 a); // the default version attribute should have no effect. Cannot have major version less than 1.
+  #[version = 1.1]
+  method derive_v1(in uint32 a); // versions MUST increase as the file moves on
+  #[version = 1.2]
+  method derive_v2(in uint32 a); // only 1 version attribute should be allowed. Order of attributes does not matter.
+  #[version = 1.255]
+  method derive_v255(out uint32 a); // Major and Minor version must each fit into a byte (0-255)
+  #[version = 2.0]
+  method derive_v2p2(in uint32 a); // Major version takes highest priority
 };
 
 interface ITest2 {

--- a/tests/src/implementation/mod.rs
+++ b/tests/src/implementation/mod.rs
@@ -81,5 +81,12 @@ fn test_singlular_object(
 
     assert_eq!(o.well_documented_method(SUCCESS_FLAG), Ok(SUCCESS_FLAG));
 
+    let expected = crate::interfaces::itest1::IDLVersion::new(2,0,0);
+    let expected_val: u32 = expected.into();
+    assert_eq!(o.api_version(), Ok(expected_val));
+    assert_eq!(2, expected.major());
+    assert_eq!(0, expected.minor());
+    assert_eq!(0, expected.patch());
+
     Ok(())
 }

--- a/tests/src/implementation/test1.rs
+++ b/tests/src/implementation/test1.rs
@@ -234,6 +234,27 @@ macro_rules! itest1_impl {
                     second_obj: Some(super::ITest1::new(2).into()),
                 })
             }
+
+            #[allow(unused_variables)]
+            fn r#derive_v0(&mut self, r#input: u32) -> Result<(), itest1::Error> {
+                Ok(())
+            }
+            #[allow(unused_variables)]
+            fn r#derive_v1(&mut self, r#input: u32) -> Result<(), itest1::Error> {
+                Ok(())
+            }
+            #[allow(unused_variables)]
+            fn r#derive_v2(&mut self, r#input: u32) -> Result<(), itest1::Error> {
+                Ok(())
+            }
+            #[allow(unused_variables)]
+            fn r#derive_v255(&mut self) -> Result<u32, itest1::Error> {
+                Ok(0xdead)
+            }
+            #[allow(unused_variables)]
+            fn r#derive_v2p2(&mut self, r#input: u32) -> Result<(), itest1::Error> {
+                Ok(())
+            }
         }
     }
 }

--- a/tests/src/object/mod.rs
+++ b/tests/src/object/mod.rs
@@ -63,6 +63,7 @@ pub union Arg {
 
 pub const OP_RELEASE: Op = 0xffffu32;
 pub const OP_RETAIN: Op = 0xfffeu32;
+pub const OP_VERSION: Op = 0x7FFFu32; // ObjectOp_LOCAL - 1
 
 #[inline]
 /// Pack argument counts into single [`Counts`] field for [`Invoke`].

--- a/tests/tests/c.rs
+++ b/tests/tests/c.rs
@@ -7,6 +7,7 @@ use idlc_test::{
     c::{create_itest1, create_itest2, create_itest3},
     implementation,
     interfaces::itest2::ITest2,
+    interfaces::itest3::IDLVersion,
 };
 
 #[test]
@@ -16,6 +17,15 @@ fn implementation() {
     assert_eq!(c_wrapper.entrypoint(Some(&input)), Ok(()));
     let c_wrapper_itest3 = unsafe { create_itest3().unwrap() };
     assert_eq!(c_wrapper_itest3.single_in(0xdead), Ok(()));
+    {
+        // Test that an IDL with no method attributes defaults to 1.0
+        let expected = IDLVersion::new(1,0,0);
+        let expected_val: u32 = expected.into();
+        assert_eq!(c_wrapper_itest3.api_version(), Ok(expected_val));
+        assert_eq!(1, expected.major());
+        assert_eq!(0, expected.minor());
+        assert_eq!(0, expected.patch());
+    }
 }
 
 #[test]


### PR DESCRIPTION
Add the ability for all Mink objects to return the interface version that is implemented by the service.

It requires:
1.	All interfaces must be versioned
2.	All Mink objects must have a 'version' method to query the service implementation.

An interface version will be derived from the max version assigned to all methods contained within it.

Versions are assigned to methods using attributes. .e.g
```c
interface Foo {
  method generateKey(out buffer a);
  #[version = 1.1]
  method generateEllipticKey(out buffer a);
}
```
Some comments about this new feature:
1.	Version attributes are optional
2.	Uses two-component versioning scheme (a.k.a. Major.Minor versioning)
4.	Unless specified, the method version is assumed to be 1.0
5.	Major and minor values must each fit into uint8_t (i.e. 0-255)
6.	Major values cannot be less than 1
7.	Only 1 version can be applied to a method
8.	A method version must be >= to the version above it (new methods must always be added to the bottom)
