### PR TITLE
Remove `#[optional]` function attribute

### DIFF
--- a/idlc_ast/src/ast.rs
+++ b/idlc_ast/src/ast.rs
@@ -177,7 +177,6 @@ impl FromStr for APIVersion {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum FunctionAttribute {
-    Optional,
     Version(APIVersion),
 }
 

--- a/idlc_ast/src/idl_grammar.pest
+++ b/idlc_ast/src/idl_grammar.pest
@@ -27,7 +27,7 @@ const         =  { const_keyword ~ primitive_type ~ ident ~ "=" ~ value ~ ";" }
 
 version              =  { ASCII_DIGIT+ ~ "." ~ ASCII_DIGIT+ }
 method_version       =  { "version" ~ WHITESPACE* ~ "=" ~ WHITESPACE* ~ version }
-supported_attributes =  { "optional" | method_version }
+supported_attributes =  { method_version }
 attribute            = ${ "#[" ~ supported_attributes ~ "]" }
 param_type           =  { ((ident | "interface") ~ bounded_array) | ((primitive_type | !"interface" ~ ident) ~ unbounded_array) | primitive_type | ident | "interface" | "buffer" }
 mutability           = @{ ("in" | "out") }

--- a/idlc_ast/src/pst.rs
+++ b/idlc_ast/src/pst.rs
@@ -133,7 +133,6 @@ impl<'a> From<Pair<'a, Rule>> for FunctionAttribute {
         let attribute = ast_unwrap!(value.into_inner().next());
         debug_assert_eq!(attribute.as_rule(), Rule::supported_attributes);
         match attribute.as_str() {
-            "optional" => Self::Optional,
             attr if attr.starts_with("version") => {
                 let method_ver = ast_unwrap!(attribute.into_inner().next());
                 debug_assert_eq!(method_ver.as_rule(), Rule::method_version);

--- a/idlc_ast/src/tests/ast.rs
+++ b/idlc_ast/src/tests/ast.rs
@@ -86,16 +86,6 @@ fn duplicately_defined_function_attribute() {
     crate::from_string(
         std::path::PathBuf::new(),
         r"interface IFoo {
-        #[optional]
-        #[optional]
-        method tmp();
-    };",
-        false,
-    )
-    .unwrap_err();
-    crate::from_string(
-        std::path::PathBuf::new(),
-        r"interface IFoo {
         #[version = 1.1]
         #[version = 1.1]
         method tmp();

--- a/idlc_ast/src/tests/parser.rs
+++ b/idlc_ast/src/tests/parser.rs
@@ -171,9 +171,6 @@ fn function() {
                           out uint32 bar);",
             "method\tfoo(in buffer req, out buffer rsp);",
             "method\nfoo(in buffer req, out buffer rsp);",
-            "#[optional] method foo(in buffer req, out buffer rsp);",
-            r"#[optional]
-              method foo(in buffer req, out buffer rsp);",
             "#[version = 1.1] method foo(in buffer req, out buffer rsp);",
             "#[version=1.1] method foo(in buffer req, out buffer rsp);",
             r"#[version = 1.1]
@@ -205,7 +202,6 @@ fn function() {
             "method bar(in 2IHWKey x,    out IHWKeyFactory2 y);",
             "methodfoo();",
             "#[unsupported_attribute] method foo(in buffer req, out buffer rsp);",
-            "#[optional]method foo(in buffer req, out buffer rsp);",
             "#[version = 1.1]method foo(in buffer req, out buffer rsp);",
             r"#[version = 1]
               method foo(in buffer req, out buffer rsp);",

--- a/idlc_ast_passes/src/functions.rs
+++ b/idlc_ast_passes/src/functions.rs
@@ -49,7 +49,6 @@ impl<'ast> CompilerPass<'ast> for Functions {
                         .iter()
                         .filter_map(|attr| match attr {
                             idlc_ast::FunctionAttribute::Version(a) => Some(a),
-                            _ => None,
                         })
                         .collect();
                     // - Ensure that no more than 1 version is listed

--- a/idlc_ast_passes/src/functions.rs
+++ b/idlc_ast_passes/src/functions.rs
@@ -47,8 +47,8 @@ impl<'ast> CompilerPass<'ast> for Functions {
                     let version_attrs: Vec<&APIVersion> = function
                         .attributes
                         .iter()
-                        .filter_map(|attr| match attr {
-                            idlc_ast::FunctionAttribute::Version(a) => Some(a),
+                        .map(|attr| match attr {
+                            idlc_ast::FunctionAttribute::Version(a) => a,
                         })
                         .collect();
                     // - Ensure that no more than 1 version is listed

--- a/idlc_codegen_c/src/interface/functions/invoke.rs
+++ b/idlc_codegen_c/src/interface/functions/invoke.rs
@@ -362,22 +362,11 @@ pub fn emit(
 
     let return_idents = super::signature::iter_to_string(signature.return_idents());
     let params = super::signature::iter_to_string(signature.params());
-    let call = if function.is_optional() {
-        weak_declarations.push_str(&format!(
-            r#"int32_t prefix##{ident}(type ctx{params}) __attribute__((weak)); \
+    weak_declarations.push_str(&format!(
+        r#"int32_t prefix##{ident}(type ctx{params}) __attribute__((weak)); \
         "#
-        ));
-        format!(
-            r"int32_t r; \
-                if (prefix##{ident} != NULL) {{ \
-                    r = prefix##{ident}(me{return_idents}); \
-                }} else {{ \
-                    return Object_ERROR_INVALID; \
-                }}"
-        )
-    } else {
-        format!(r"int32_t r = prefix##{ident}(me{return_idents});")
-    };
+    ));
+    let call = format!(r"int32_t r = prefix##{ident}(me{return_idents});");
 
     let counts = format!(
         "{0}, {1}, {2}, {3}",

--- a/idlc_codegen_c/src/interface/functions/invoke.rs
+++ b/idlc_codegen_c/src/interface/functions/invoke.rs
@@ -350,7 +350,6 @@ impl idlc_codegen::functions::ParameterVisitor for Invoke {
 
 pub fn emit(
     function: &idlc_mir::Function,
-    weak_declarations: &mut String,
     iface_ident: &str,
     signature: &super::signature::Signature,
     counts: &idlc_codegen::counts::Counter,
@@ -361,11 +360,6 @@ pub fn emit(
     let invoke = Invoke::new(function, is_no_typed_objects);
 
     let return_idents = super::signature::iter_to_string(signature.return_idents());
-    let params = super::signature::iter_to_string(signature.params());
-    weak_declarations.push_str(&format!(
-        r#"int32_t prefix##{ident}(type ctx{params}) __attribute__((weak)); \
-        "#
-    ));
     let call = format!(r"int32_t r = prefix##{ident}(me{return_idents});");
 
     let counts = format!(

--- a/idlc_codegen_c/src/interface/mod.rs
+++ b/idlc_codegen_c/src/interface/mod.rs
@@ -127,7 +127,6 @@ pub fn emit_interface_invoke(interface: &Interface, is_no_typed_objects: bool) -
     let ident = interface.ident.to_string();
 
     let mut invokes = String::new();
-    let mut weak_declarations = String::new();
 
     // need to have all of the base-class functions
     interface.iter().skip(1).for_each(|iface| {
@@ -138,7 +137,6 @@ pub fn emit_interface_invoke(interface: &Interface, is_no_typed_objects: bool) -
                     functions::signature::Signature::new(f, &counts, is_no_typed_objects);
                 invokes.push_str(&functions::invoke::emit(
                     f,
-                    &mut weak_declarations,
                     &iface.ident,
                     &signature,
                     &counts,
@@ -154,7 +152,6 @@ pub fn emit_interface_invoke(interface: &Interface, is_no_typed_objects: bool) -
             let signature = functions::signature::Signature::new(f, &counts, is_no_typed_objects);
             invokes.push_str(&functions::invoke::emit(
                 f,
-                &mut weak_declarations,
                 &ident,
                 &signature,
                 &counts,
@@ -169,19 +166,8 @@ pub fn emit_interface_invoke(interface: &Interface, is_no_typed_objects: bool) -
 
     let APIVersion { major, minor } = interface.get_version();
 
-    // weak_delcarations goes inside `func` to preserve the expected when the macro is instantiated
-    // with `static IFoo_DEFINE_INVOKE`. It is OK to declare functions within functions for C.
     format!(
         r#"{typed_objects}
-#ifdef __clang__
-#define __compiler_pragma_pre \
-    _Pragma("clang diagnostic push") \
-    _Pragma("clang diagnostic ignored \"-Wignored-attributes\"")
-#define __compiler_pragma_post _Pragma("clang diagnostic pop")
-#else
-#define __compiler_pragma_pre
-#define __compiler_pragma_post
-#endif
 
 #define {ident}_VERSION_MAJOR {major}
 #define {ident}_VERSION_MINOR {minor}
@@ -190,9 +176,6 @@ pub fn emit_interface_invoke(interface: &Interface, is_no_typed_objects: bool) -
 #define {ident}_DEFINE_INVOKE(func, prefix, type) \
     int32_t func(ObjectCxt {CONTEXT}, ObjectOp {OP_CODE}, ObjectArg *{ARGS}, ObjectCounts {COUNTS}) \
     {{ \
-        __compiler_pragma_pre \
-        {weak_declarations} \
-        __compiler_pragma_post \
         type me = (type) {CONTEXT}; \
         switch (ObjectOp_methodID({OP_CODE})) {{ \
             case Object_OP_release: {{ \

--- a/idlc_codegen_cpp/src/interface/functions/invoke.rs
+++ b/idlc_codegen_cpp/src/interface/functions/invoke.rs
@@ -193,12 +193,10 @@ pub fn emit(
     if !params.is_empty() {
         params.remove(0);
     }
-    if function.is_optional() {
-        weak_declarations.push_str(&format!(
-            r#"
+    weak_declarations.push_str(&format!(
+        r#"
     virtual int32_t {ident}({params}) {{ return Object_ERROR_INVALID; }}"#
-        ));
-    }
+    ));
 
     let call = format!("int32_t r = {ident}({return_idents});");
 

--- a/idlc_codegen_cpp/src/interface/functions/invoke.rs
+++ b/idlc_codegen_cpp/src/interface/functions/invoke.rs
@@ -174,7 +174,6 @@ impl idlc_codegen::functions::ParameterVisitor for Invoke {
 
 pub fn emit(
     function: &idlc_mir::Function,
-    weak_declarations: &mut String,
     signature: &super::signature::Signature,
     counts: &idlc_codegen::counts::Counter,
 ) -> String {
@@ -187,16 +186,6 @@ pub fn emit(
     if !return_idents.is_empty() {
         return_idents.remove(0);
     }
-
-    let mut params =
-        idlc_codegen_c::interface::functions::signature::iter_to_string(signature.params());
-    if !params.is_empty() {
-        params.remove(0);
-    }
-    weak_declarations.push_str(&format!(
-        r#"
-    virtual int32_t {ident}({params}) {{ return Object_ERROR_INVALID; }}"#
-    ));
 
     let call = format!("int32_t r = {ident}({return_idents});");
 

--- a/idlc_codegen_cpp/src/interface/mod.rs
+++ b/idlc_codegen_cpp/src/interface/mod.rs
@@ -142,7 +142,6 @@ pub fn emit_interface_invoke(interface: &Interface) -> String {
     let ident = interface.ident.to_string();
 
     let mut invokes = String::new();
-    let mut weak_declarations = String::new();
 
     // need to have all of the base-class functions
     interface.iter().skip(1).for_each(|iface| {
@@ -151,12 +150,7 @@ pub fn emit_interface_invoke(interface: &Interface) -> String {
                 let counts = idlc_codegen::counts::Counter::new(f);
                 let signature = functions::signature::Signature::new(f, &counts);
 
-                invokes.push_str(&functions::invoke::emit(
-                    f,
-                    &mut weak_declarations,
-                    &signature,
-                    &counts,
-                ));
+                invokes.push_str(&functions::invoke::emit(f, &signature, &counts));
             }
         })
     });
@@ -166,12 +160,7 @@ pub fn emit_interface_invoke(interface: &Interface) -> String {
             let counts = idlc_codegen::counts::Counter::new(f);
             let signature = functions::signature::Signature::new(f, &counts);
 
-            invokes.push_str(&functions::invoke::emit(
-                f,
-                &mut weak_declarations,
-                &signature,
-                &counts,
-            ));
+            invokes.push_str(&functions::invoke::emit(f, &signature, &counts));
         }
     }
 
@@ -192,7 +181,6 @@ class {ident}ImplBase : protected ImplBase, public I{ident} {{
                   (VERSION_PATCH & PATCH_MASK);
         return Object_OK;
     }}
-{weak_declarations}
   protected:
 {INDENT}virtual int32_t invoke(ObjectOp {OP_CODE}, ObjectArg* {ARGS}, ObjectCounts {COUNTS}) {{
 {INDENT}{INDENT}switch (ObjectOp_methodID({OP_CODE})) {{

--- a/idlc_codegen_java/src/interface/functions/traits.rs
+++ b/idlc_codegen_java/src/interface/functions/traits.rs
@@ -1,8 +1,6 @@
 // Copyright (c) 2024, Qualcomm Innovation Center, Inc. All rights reserved.
 // SPDX-License-Identifier: BSD-3-Clause
 
-use std::borrow::Cow;
-
 pub fn emit(
     function: &idlc_mir::Function,
     documentation: &str,
@@ -10,21 +8,9 @@ pub fn emit(
 ) -> String {
     let ident = &function.ident;
     let params = super::signature::iter_to_string(signature.params());
-    let (pre, post) = if function.is_optional() {
-        (
-            "default ",
-            Cow::Owned(
-                r"{ throw new IMinkObject.InvokeException(IMinkObject.ERROR_INVALID); }"
-                    .to_string(),
-            ),
-        )
-    } else {
-        ("", Cow::Borrowed(";"))
-    };
-
     format!(
         r#"{documentation}
-    {pre}void {ident}({params}) throws IMinkObject.InvokeException{post}
+    default void {ident}({params}) throws IMinkObject.InvokeException {{ throw new IMinkObject.InvokeException(IMinkObject.ERROR_INVALID); }}
     "#
     )
 }

--- a/idlc_codegen_java/src/interface/functions/traits.rs
+++ b/idlc_codegen_java/src/interface/functions/traits.rs
@@ -10,7 +10,7 @@ pub fn emit(
     let params = super::signature::iter_to_string(signature.params());
     format!(
         r#"{documentation}
-    default void {ident}({params}) throws IMinkObject.InvokeException {{ throw new IMinkObject.InvokeException(IMinkObject.ERROR_INVALID); }}
+    void {ident}({params}) throws IMinkObject.InvokeException;
     "#
     )
 }

--- a/idlc_codegen_rust/src/interface/functions/traits.rs
+++ b/idlc_codegen_rust/src/interface/functions/traits.rs
@@ -1,8 +1,6 @@
 // Copyright (c) 2024, Qualcomm Innovation Center, Inc. All rights reserved.
 // SPDX-License-Identifier: BSD-3-Clause
 
-use std::borrow::Cow;
-
 use crate::interface::mink_primitives::GENERIC_ERROR;
 pub fn emit(
     function: &idlc_mir::Function,
@@ -12,14 +10,12 @@ pub fn emit(
     let ident = &function.ident;
     let returns = super::signature::iter_to_string(signature.return_types());
     let params = super::signature::iter_to_string(signature.params());
-    let definition = if function.is_optional() {
-        Cow::Owned(format!("{{ Err({GENERIC_ERROR}::INVALID.into()) }}"))
-    } else {
-        Cow::Borrowed(";")
-    };
     format!(
         r#"
     {documentation}
-    fn r#{ident}(&mut self, {params}) -> Result<({returns}), Error>{definition}"#
+    fn r#{ident}(&mut self, {params}) -> Result<({returns}), Error> {{
+        Err({GENERIC_ERROR}::INVALID.into())
+    }}
+    "#
     )
 }

--- a/idlc_codegen_rust/src/interface/functions/traits.rs
+++ b/idlc_codegen_rust/src/interface/functions/traits.rs
@@ -1,7 +1,6 @@
 // Copyright (c) 2024, Qualcomm Innovation Center, Inc. All rights reserved.
 // SPDX-License-Identifier: BSD-3-Clause
 
-use crate::interface::mink_primitives::GENERIC_ERROR;
 pub fn emit(
     function: &idlc_mir::Function,
     documentation: &str,
@@ -13,9 +12,7 @@ pub fn emit(
     format!(
         r#"
     {documentation}
-    fn r#{ident}(&mut self, {params}) -> Result<({returns}), Error> {{
-        Err({GENERIC_ERROR}::INVALID.into())
-    }}
+    fn r#{ident}(&mut self, {params}) -> Result<({returns}), Error>
     "#
     )
 }

--- a/idlc_codegen_rust/src/interface/mod.rs
+++ b/idlc_codegen_rust/src/interface/mod.rs
@@ -70,7 +70,10 @@ pub fn emit(interface: &Interface) -> String {
             });
     });
 
-    let trait_functions = trait_functions.concat();
+    let mut trait_functions = trait_functions.join(";");
+    if !trait_functions.is_empty() {
+        trait_functions.push(';');
+    }
     let implementations = implementations.concat();
     let invoke_arms = invoke_arms.join(",");
 

--- a/idlc_mir/src/mir.rs
+++ b/idlc_mir/src/mir.rs
@@ -459,14 +459,9 @@ pub struct Function {
 }
 
 impl Function {
-    pub fn is_optional(&self) -> bool {
-        self.attributes
-            .contains(&idlc_ast::FunctionAttribute::Optional)
-    }
     pub fn get_version(&self) -> Option<&APIVersion> {
         self.attributes.iter().find_map(|e| match e {
             idlc_ast::FunctionAttribute::Version(a) => Some(a),
-            _ => None,
         })
     }
 }

--- a/idlc_mir/src/mir.rs
+++ b/idlc_mir/src/mir.rs
@@ -460,9 +460,12 @@ pub struct Function {
 
 impl Function {
     pub fn get_version(&self) -> Option<&APIVersion> {
-        self.attributes.iter().find_map(|e| match e {
-            idlc_ast::FunctionAttribute::Version(a) => Some(a),
-        })
+        self.attributes
+            .iter()
+            .map(|e| match e {
+                idlc_ast::FunctionAttribute::Version(a) => a,
+            })
+            .next()
     }
 }
 

--- a/tests/c/header.h
+++ b/tests/c/header.h
@@ -88,10 +88,8 @@ int32_t itest1_multiple_primitive(struct CTest1 *ctx, const void *unused_ptr,
                                   void *unused5_ptr, size_t unused5_len,
                                   size_t *unused5_lenout);
 
-int32_t
-itest1_primitive_plus_struct_in(struct CTest1 *ctx,
-                                const SingleEncapsulated *encapsulated_ptr,
-                                uint32_t magic_val);
+int32_t itest1_primitive_plus_struct_in(
+    struct CTest1 *ctx, const SingleEncapsulated *encapsulated_ptr, uint32_t magic_val);
 
 int32_t itest1_primitive_plus_struct_out(struct CTest1 *ctx,
                                          SingleEncapsulated *encapsulated_ptr,
@@ -110,11 +108,11 @@ int32_t itest1_struct_array_in(struct CTest1 *ctx, const Collection *s_in_ptr, s
 
 int32_t itest1_struct_array_out(struct CTest1 *ctx, Collection *s_out_ptr, size_t s_out_len, size_t *s_out_lenout);
 
-int32_t itest1_well_documented_method_real(struct CTest1 *ctx, uint32_t foo_val,
-                                           uint32_t *bar_ptr);
+int32_t itest1_well_documented_method(struct CTest1 *ctx, uint32_t foo_val,
+                                      uint32_t *bar_ptr);
 
-int32_t itest1_test_obj_array_in(struct CTest1 *ctx,
-                                 const Object (*o_in_ptr)[3], uint32_t *a_ptr);
+int32_t itest1_test_obj_array_in(struct CTest1 *ctx, const Object (*o_in_ptr)[3],
+                                 uint32_t *a_ptr);
 
 int32_t itest1_test_obj_array_out(struct CTest1 *ctx, Object (*o_ptr)[3],
                                   uint32_t *a_ptr);

--- a/tests/c/invoke.c
+++ b/tests/c/invoke.c
@@ -153,10 +153,8 @@ int32_t itest1_multiple_primitive(struct CTest1 *ctx, const void *unused_ptr,
   return Object_OK;
 }
 
-int32_t
-itest1_primitive_plus_struct_in(struct CTest1 *ctx,
-                                const SingleEncapsulated *encapsulated_ptr,
-                                uint32_t magic_val) {
+int32_t itest1_primitive_plus_struct_in(
+    struct CTest1 *ctx, const SingleEncapsulated *encapsulated_ptr, uint32_t magic_val) {
   ASSERT(encapsulated_ptr->inner == SUCCESS_FLAG && magic_val == SUCCESS_FLAG);
   return Object_OK;
 }
@@ -209,18 +207,15 @@ int32_t itest1_struct_array_out(struct CTest1 *ctx, Collection *s_out_ptr, size_
   return Object_OK;
 }
 
-int32_t itest1_well_documented_method_real(struct CTest1 *ctx, uint32_t foo_val,
-                                           uint32_t *bar_ptr) {
+int32_t itest1_well_documented_method(struct CTest1 *ctx, uint32_t foo_val,
+                                      uint32_t *bar_ptr) {
   ASSERT(foo_val == SUCCESS_FLAG);
   *bar_ptr = SUCCESS_FLAG;
   return Object_OK;
 }
 
-#define itest1_well_documented_method(a, b, c)                                 \
-  itest1_well_documented_method_real(a, b, c)
-
-int32_t itest1_test_obj_array_in(struct CTest1 *ctx,
-                                 const Object (*o_in_ptr)[3], uint32_t *a_ptr) {
+int32_t itest1_test_obj_array_in(struct CTest1 *ctx, const Object (*o_in_ptr)[3],
+                                 uint32_t *a_ptr) {
   for (size_t i = 0; i < 3; i++) {
     Object o = (*o_in_ptr)[i];
     if (!Object_isNull(o)) {
@@ -347,7 +342,7 @@ int32_t itest2_entrypoint(void *ctx, Object itest1) {
   Object_ASSIGN_NULL(output_struct.second_obj);
   Object_ASSIGN_NULL(output_struct.should_be_empty);
 
-  ASSERT(ITest1_unimplemented(itest1, 3) == Object_ERROR_INVALID);
+  ASSERT(ITest1_un_implemented(itest1, 3) == Object_ERROR_INVALID);
 
   return Object_OK;
 }
@@ -457,7 +452,7 @@ int32_t itest3_struct_array_out(struct CTest1 *ctx, Collection *s_out_ptr, size_
 
 int32_t itest3_well_documented_method(struct CTest1 *ctx, uint32_t foo_val,
                                            uint32_t *bar_ptr) {
-  return itest1_well_documented_method_real(ctx, foo_val, bar_ptr);
+  return itest1_well_documented_method(ctx, foo_val, bar_ptr);
 }
 
 int32_t itest3_test_obj_array_in(struct CTest1 *ctx,

--- a/tests/c/invoke.c
+++ b/tests/c/invoke.c
@@ -342,8 +342,6 @@ int32_t itest2_entrypoint(void *ctx, Object itest1) {
   Object_ASSIGN_NULL(output_struct.second_obj);
   Object_ASSIGN_NULL(output_struct.should_be_empty);
 
-  ASSERT(ITest1_un_implemented(itest1, 3) == Object_ERROR_INVALID);
-
   return Object_OK;
 }
 

--- a/tests/cpp/main.cpp
+++ b/tests/cpp/main.cpp
@@ -240,8 +240,6 @@ public:
     Object_ASSIGN_NULL(output_struct.second_obj);
     Object_ASSIGN_NULL(output_struct.should_be_empty);
 
-    ASSERT(me.un_implemented(3) == Object_ERROR_INVALID);
-
     uint32_t version = 0;
     CHECK_OK(me.api_version(&version));
     uint32_t major = (version >> ITest1::MAJOR_SHIFT) & ITest1::MAJOR_MASK;

--- a/tests/cpp/main.cpp
+++ b/tests/cpp/main.cpp
@@ -112,7 +112,7 @@ public:
         &this->ctest, (c::Collection *)s_out_ptr, s_out_len, s_out_lenout);
   }
   int32_t well_documented_method(uint32_t foo_val, uint32_t *bar_ptr) {
-    return c::itest1_well_documented_method_real(&this->ctest, foo_val, bar_ptr);
+    return c::itest1_well_documented_method(&this->ctest, foo_val, bar_ptr);
   }
   int32_t test_obj_array_in(const ITest1 (&o_in_ptr)[3], uint32_t *a_ptr) {
     for (size_t i = 0; i < 3; i++) {
@@ -240,7 +240,7 @@ public:
     Object_ASSIGN_NULL(output_struct.second_obj);
     Object_ASSIGN_NULL(output_struct.should_be_empty);
 
-    ASSERT(me.unimplemented(3) == Object_ERROR_INVALID);
+    ASSERT(me.un_implemented(3) == Object_ERROR_INVALID);
 
     uint32_t version = 0;
     CHECK_OK(me.api_version(&version));
@@ -357,7 +357,7 @@ public:
         &this->ctest, (c::Collection *)s_out_ptr, s_out_len, s_out_lenout);
   }
   int32_t well_documented_method(uint32_t foo_val, uint32_t *bar_ptr) {
-    return c::itest1_well_documented_method_real(&this->ctest, foo_val, bar_ptr);
+    return c::itest1_well_documented_method(&this->ctest, foo_val, bar_ptr);
   }
   int32_t test_obj_array_in(const ITest1 (&o_in_ptr)[3], uint32_t *a_ptr) {
     for (size_t i = 0; i < 3; i++) {

--- a/tests/idl/ITest.idl
+++ b/tests/idl/ITest.idl
@@ -64,8 +64,6 @@ interface ITest1 {
   method test_obj_array_in(in ITest1[3] o_in, out uint32 a);
   method test_obj_array_out(out ITest1[3] out, out uint32 a);
   method objects_in_struct(in ObjInStruct input, out ObjInStruct output);
-  #[optional]
-  method unimplemented(in uint32 foo); // this method should NOT have an implementation and that is OK
 
   #[version = 1.0]
   method derive_v0(in uint32 a); // the default version attribute should have no effect. Cannot have major version less than 1.

--- a/tests/src/implementation/test2.rs
+++ b/tests/src/implementation/test2.rs
@@ -55,7 +55,7 @@ impl IITest2 for ITest2 {
         super::test_singlular_object(output.second_obj.as_ref()).unwrap();
 
         assert_eq!(
-            o.unimplemented(3),
+            o.un_implemented(3),
             Err(crate::object::error::generic::INVALID.into())
         );
 

--- a/tests/src/implementation/test2.rs
+++ b/tests/src/implementation/test2.rs
@@ -54,11 +54,6 @@ impl IITest2 for ITest2 {
         assert_eq!(output.should_be_empty, None);
         super::test_singlular_object(output.second_obj.as_ref()).unwrap();
 
-        assert_eq!(
-            o.un_implemented(3),
-            Err(crate::object::error::generic::INVALID.into())
-        );
-
         Ok(())
     }
 }


### PR DESCRIPTION
The `#[optional]` attribute is not documented and was never recommended for use. Although it does solve some integration issues, it does not make sense from a Mink IDL perspective. Methods are never guaranteed to be implemented on the server side so the IDL should not be used to indicate any implementation details.

Removing it to prevent issues down the road.