### PR TITLE
fix: Add rust-version to top-level Cargo.toml

### DIFF
--- a/idlc/Cargo.toml
+++ b/idlc/Cargo.toml
@@ -2,6 +2,7 @@
 name = "idlc"
 version.workspace = true
 edition = "2021"
+rust-version = "1.81.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 


### PR DESCRIPTION
This serves as a test of the release-please workflow