### PR TITLE
ci: Push workspace version to each crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,3 @@ lto = true
 codegen-units = 1
 strip = true
 panic = "abort"
-
-[workspace.package]
-version = "0.2.3"

--- a/idlc/Cargo.toml
+++ b/idlc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "idlc"
-version.workspace = true
+version = "0.2.3"
 edition = "2021"
 rust-version = "1.81.0"
 

--- a/idlc_ast/Cargo.toml
+++ b/idlc_ast/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "idlc_ast"
-version.workspace = true
+version = "0.2.3"
 edition = "2021"
 authors = [ "Arvind Mukund<arvimuku@quicinc.com" ]
 description = "AST structure for IDL; contains grammar and AST generators"

--- a/idlc_codegen/Cargo.toml
+++ b/idlc_codegen/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "idlc_codegen"
-version.workspace = true
+version = "0.2.3"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/idlc_codegen_c/Cargo.toml
+++ b/idlc_codegen_c/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "idlc_codegen_c"
-version.workspace = true
+version = "0.2.3"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/idlc_codegen_cpp/Cargo.toml
+++ b/idlc_codegen_cpp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "idlc_codegen_cpp"
-version.workspace = true
+version = "0.2.3"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/idlc_codegen_java/Cargo.toml
+++ b/idlc_codegen_java/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "idlc_codegen_java"
-version.workspace = true
+version = "0.2.3"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/idlc_codegen_rust/Cargo.toml
+++ b/idlc_codegen_rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "idlc_codegen_rust"
-version.workspace = true
+version = "0.2.3"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/idlc_errors/Cargo.toml
+++ b/idlc_errors/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "idlc_errors"
-version.workspace = true
+version = "0.2.3"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/idlc_mir/Cargo.toml
+++ b/idlc_mir/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "idlc_mir"
-version.workspace = true
+version = "0.2.3"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/idlc_mir_passes/Cargo.toml
+++ b/idlc_mir_passes/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "idlc_mir_passes"
-version.workspace = true
+version = "0.2.3"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html


### PR DESCRIPTION
This is a known, very specific failure mode when combining release-please + Rust workspaces.

`cargo-workspace plugin` expects to find a literal package.version = "x.y.z" inside each workspace member’s Cargo.toml.

It does not currently support:
- version.workspace = true
- [workspace.package].version inheritance