### PR TITLE
ci: Virtual workspace fixup

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -3,9 +3,9 @@
 
   "release-type": "rust",
 
+  "plugins": ["cargo-workspace"],
+
   "packages": {
-    ".": {
-      "plugins": ["cargo-workspace"]
-    }
+      ".": {}
   }
 }


### PR DESCRIPTION
- "." is treated as the workspace root
- cargo-workspace:
  - Reads [workspace.members]
  - Finds only real crates
  - Parses each crate’s [package].version
- release-please no longer tries to interpret the workspace as a crate

This is the canonical configuration for a Rust workspace with:
- a virtual root manifest
- multiple member crates
- a single coordinated release