### PR TITLE
Crates individual versions

### DIFF
--- a/.github/release-please-config.json
+++ b/.github/release-please-config.json
@@ -4,7 +4,6 @@
   "packages": {
     ".": {
       "release-type": "simple",
-      "extra-files": ["Cargo.toml"],
       "changelog-sections": [
         { "type": "feat", "section": "Features" },
         { "type": "fix", "section": "Bug Fixes" },

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,4 +27,4 @@ strip = true
 panic = "abort"
 
 [workspace.package]
-version = "0.2.3" # x-release-please-version
+version = "0.2.3"

--- a/idlc/Cargo.toml
+++ b/idlc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "idlc"
-version.workspace = true
+version = "0.2.3"
 edition = "2021"
 rust-version = "1.81.0"
 

--- a/idlc_ast/Cargo.toml
+++ b/idlc_ast/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "idlc_ast"
-version.workspace = true
+version = "0.2.3"
 edition = "2021"
 authors = [ "Arvind Mukund<arvimuku@quicinc.com" ]
 description = "AST structure for IDL; contains grammar and AST generators"

--- a/idlc_codegen/Cargo.toml
+++ b/idlc_codegen/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "idlc_codegen"
-version.workspace = true
+version = "0.2.3"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/idlc_codegen_c/Cargo.toml
+++ b/idlc_codegen_c/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "idlc_codegen_c"
-version.workspace = true
+version = "0.2.3"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/idlc_codegen_cpp/Cargo.toml
+++ b/idlc_codegen_cpp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "idlc_codegen_cpp"
-version.workspace = true
+version = "0.2.3"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/idlc_codegen_java/Cargo.toml
+++ b/idlc_codegen_java/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "idlc_codegen_java"
-version.workspace = true
+version = "0.2.3"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/idlc_codegen_rust/Cargo.toml
+++ b/idlc_codegen_rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "idlc_codegen_rust"
-version.workspace = true
+version = "0.2.3"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/idlc_errors/Cargo.toml
+++ b/idlc_errors/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "idlc_errors"
-version.workspace = true
+version = "0.2.3"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/idlc_mir/Cargo.toml
+++ b/idlc_mir/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "idlc_mir"
-version.workspace = true
+version = "0.2.3"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/idlc_mir_passes/Cargo.toml
+++ b/idlc_mir_passes/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "idlc_mir_passes"
-version.workspace = true
+version = "0.2.3"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html


### PR DESCRIPTION
To better track changes within the workspace, we should version each sub-crate and workspace separately.

Essentially every change will roll up to the workspace but not every release will involve every sub-crate.