### PR TITLE
fix(idlc): Make GIT_HASH optional for long version

### DIFF
--- a/idlc/build.rs
+++ b/idlc/build.rs
@@ -6,8 +6,14 @@ use std::process::Command;
 pub fn main() {
     let output = Command::new("git")
         .args(["describe", "--always", "--abbrev=40", "--dirty"])
-        .output()
-        .unwrap();
-    let git_hash = std::str::from_utf8(&output.stdout).unwrap();
+        .output();
+
+    let git_hash = match output {
+        Ok(output) if output.status.success() => {
+            std::str::from_utf8(&output.stdout).unwrap().to_string()
+        }
+        _ => "unknown".to_string(),
+    };
+
     println!("cargo:rustc-env=GIT_HASH={git_hash}");
 }

--- a/idlc/src/cli.rs
+++ b/idlc/src/cli.rs
@@ -2,12 +2,18 @@
 // SPDX-License-Identifier: BSD-3-Clause
 
 fn long_version() -> &'static str {
-    format!(
-        "{}\nCompiled from (git hash): {}",
-        env!("CARGO_PKG_VERSION"),
-        env!("GIT_HASH")
-    )
-    .leak()
+    let git_hash = env!("GIT_HASH");
+
+    if git_hash == "unknown" {
+        env!("CARGO_PKG_VERSION")
+    } else {
+        format!(
+            "{}\nCompiled from (git hash): {}",
+            env!("CARGO_PKG_VERSION"),
+            git_hash
+        )
+        .leak()
+    }
 }
 
 #[derive(clap::Parser)]


### PR DESCRIPTION
Only include GIT_HASH in the long version output when Git metadata is available.

Previously, the long version always assumed that GIT_HASH was present, which is not reliable in isolated build environments such as Debian package builds with sbuild, where the source tree may not contain .git metadata.

Make the long version generation conditional so that:
- the Git hash is shown when available
- clap falls back to the normal version output when it is not

Signed-off-by: Abhinaba Rakshit <abhinaba.rakshit@oss.qualcomm.com>