### PR TITLE
fix: Disallow array of Mink Object in a struct

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for more detail.
 
     ```
   - Structs with Objects inside cannot be used in an array
+  - Struct fields cannot be an array of Objects
 
 ## Restrictions
 - No cyclic includes.

--- a/idlc_ast_passes/src/struct_verifier.rs
+++ b/idlc_ast_passes/src/struct_verifier.rs
@@ -38,6 +38,8 @@ pub enum Error {
     },
     #[error("struct `{parent}` contains duplicate field names: `{names:?}`")]
     StructFieldSameName { parent: Ident, names: Vec<Ident> },
+    #[error("struct `{parent}` contains Object array: `{obj_arr}`. Object arrays are not allowed as struct fields.")]
+    StructFieldObjArray { parent: Ident, obj_arr: Ident },
 }
 
 impl StructVerifier {
@@ -62,6 +64,29 @@ impl StructVerifier {
 
                 let (ty, count) = field.r#type();
                 let count = count.get() as usize;
+
+                // Checks for array fields
+                if count > 1 {
+                    match ty {
+                        // literally defined as 'interface' type
+                        Type::Interface => {
+                            return Err(Error::StructFieldObjArray {
+                                parent: node.ident.clone(),
+                                obj_arr: ident.clone(),
+                            });
+                        }
+                        Type::Custom(c) => {
+                            // Need to clarify if custom type is actually a named interface
+                            if idl_store.iface_lookup(c).is_some() {
+                                return Err(Error::StructFieldObjArray {
+                                    parent: node.ident.clone(),
+                                    obj_arr: c.clone(),
+                                });
+                            };
+                        }
+                        _ => {}
+                    }
+                }
 
                 let (i_size, i_alignment) = match ty {
                     Type::Primitive(p) => (p.size(), p.alignment()),

--- a/idlc_ast_passes/src/struct_verifier.rs
+++ b/idlc_ast_passes/src/struct_verifier.rs
@@ -75,14 +75,12 @@ impl StructVerifier {
                                 obj_arr: ident.clone(),
                             });
                         }
-                        Type::Custom(c) => {
-                            // Need to clarify if custom type is actually a named interface
-                            if idl_store.iface_lookup(c).is_some() {
-                                return Err(Error::StructFieldObjArray {
-                                    parent: node.ident.clone(),
-                                    obj_arr: c.clone(),
-                                });
-                            };
+                        // Custom type that is a known Mink interface
+                        Type::Custom(c) if idl_store.iface_lookup(c).is_some() => {
+                            return Err(Error::StructFieldObjArray {
+                                parent: node.ident.clone(),
+                                obj_arr: c.clone(),
+                            });
                         }
                         _ => {}
                     }

--- a/idlc_ast_passes/tests/structs.rs
+++ b/idlc_ast_passes/tests/structs.rs
@@ -141,15 +141,16 @@ fn embedded_object_custom() {
 }
 
 #[test]
+#[should_panic]
 fn embedded_object_arr() {
-    assert!(verify(
+    verify(
         r"
         interface Foo {};
         struct A {
             Foo[4] f;
-        };"
+        };",
     )
-    .is_ok());
+    .unwrap();
 }
 
 #[test]

--- a/tests/idl/ITest.idl
+++ b/tests/idl/ITest.idl
@@ -7,12 +7,6 @@ struct ObjInStruct {
   ITest1 second_obj;
 };
 
-struct ObjArrInStruct {
-    interface single;
-    // interface[2] double;
-    ITest1[3] triple;
-};
-
 struct F1 {
     uint32 a;
 };

--- a/tests/idl/ITest.idl
+++ b/tests/idl/ITest.idl
@@ -7,6 +7,12 @@ struct ObjInStruct {
   ITest1 second_obj;
 };
 
+struct ObjArrInStruct {
+    interface single;
+    // interface[2] double;
+    ITest1[3] triple;
+};
+
 struct F1 {
     uint32 a;
 };


### PR DESCRIPTION
For the sake of simplicity, check for and disallow arrays of Objects embedded inside of structs.