### PR TITLE
fix!: C++ implementation of IDL versioning with old impl_base.hpp

### DIFF
--- a/idlc_codegen_c/src/interface/mod.rs
+++ b/idlc_codegen_c/src/interface/mod.rs
@@ -111,10 +111,10 @@ static inline int32_t
 }}
 
 static inline int32_t
-{ident}_{VERSION_FUNC_NAME}(Object self, uint32_t *a_ptr)
+{ident}_{VERSION_FUNC_NAME}(Object self, uint32_t *version_ptr)
 {{
     ObjectArg a[] = {{
-        {{.b = (ObjectBuf) {{ a_ptr, sizeof(uint32_t) }} }},
+        {{.b = (ObjectBuf) {{ version_ptr, sizeof(uint32_t) }} }},
     }};
     return Object_invoke(self, Object_OP_version, a, ObjectCounts_pack(0, 1, 0, 0));
 }}

--- a/idlc_codegen_cpp/src/interface/mod.rs
+++ b/idlc_codegen_cpp/src/interface/mod.rs
@@ -125,9 +125,9 @@ class {ident} : public I{ident}, public ProxyBase {{
     {ident}() {{}}
     {ident}(Object impl) : ProxyBase(impl) {{}}
     virtual ~{ident}() {{}}
-    virtual int32_t {VERSION_FUNC_NAME}(uint32_t *a_ptr) {{
+    virtual int32_t {VERSION_FUNC_NAME}(uint32_t *version_ptr) {{
         ObjectArg a[] = {{
-            {{.b = (ObjectBuf) {{ a_ptr, sizeof(uint32_t) }} }},
+            {{.b = (ObjectBuf) {{ version_ptr, sizeof(uint32_t) }} }},
         }};
         return invoke(Object_OP_version, a, ObjectCounts_pack(0, 1, 0, 0));
     }}

--- a/idlc_codegen_cpp/src/interface/mod.rs
+++ b/idlc_codegen_cpp/src/interface/mod.rs
@@ -175,15 +175,19 @@ class {ident}ImplBase : protected ImplBase, public I{ident} {{
     static constexpr uint16_t VERSION_MAJOR = UINT16_C({major});
     static constexpr uint16_t VERSION_MINOR = UINT16_C({minor});
     static constexpr uint16_t VERSION_PATCH = 0;
-    virtual int32_t {VERSION_FUNC_NAME}(uint32_t *a_ptr) {{
-        *a_ptr = ((VERSION_MAJOR & MAJOR_MASK) << MAJOR_SHIFT) | \
-                 ((VERSION_MINOR & MINOR_MASK) << MINOR_SHIFT) | \
-                  (VERSION_PATCH & PATCH_MASK);
-        return Object_OK;
-    }}
   protected:
 {INDENT}virtual int32_t invoke(ObjectOp {OP_CODE}, ObjectArg* {ARGS}, ObjectCounts {COUNTS}) {{
 {INDENT}{INDENT}switch (ObjectOp_methodID({OP_CODE})) {{
+{INDENT}{INDENT}{INDENT}case Object_OP_version: {{
+{INDENT}{INDENT}{INDENT}{INDENT}if (k != ObjectCounts_pack(0, 1, 0, 0) || a[0].b.size != 4){{
+{INDENT}{INDENT}{INDENT}{INDENT}{INDENT}break;
+{INDENT}{INDENT}{INDENT}{INDENT}}}
+{INDENT}{INDENT}{INDENT}{INDENT}uint32_t *version_ptr = (uint32_t*)a[0].b.ptr;
+{INDENT}{INDENT}{INDENT}{INDENT}*version_ptr = ((VERSION_MAJOR & MAJOR_MASK) << MAJOR_SHIFT) | \
+{INDENT}{INDENT}{INDENT}{INDENT}               ((VERSION_MINOR & MINOR_MASK) << MINOR_SHIFT) | \
+{INDENT}{INDENT}{INDENT}{INDENT}                (VERSION_PATCH & PATCH_MASK);
+{INDENT}{INDENT}{INDENT}{INDENT}return Object_OK;
+{INDENT}{INDENT}{INDENT}}}
 {invokes}
 {INDENT}{INDENT}{INDENT}default: {{ return Object_ERROR_INVALID; }}
 {INDENT}{INDENT}}}

--- a/idlc_codegen_rust/src/interface/mod.rs
+++ b/idlc_codegen_rust/src/interface/mod.rs
@@ -109,11 +109,11 @@ pub fn emit(interface: &Interface) -> String {
     /// '{ident}' interface at version '{interface_version}'
     impl {ident} {{
         pub fn r#{VERSION_FUNC_NAME}(&self) -> Result<(u32), Error> {{
-            let mut r#a = std::mem::MaybeUninit::<u32>::uninit();
+            let mut r#version = std::mem::MaybeUninit::<u32>::uninit();
             let mut args = [
                 crate::object::Arg {{
                     bi: crate::object::BufIn {{
-                        ptr: std::ptr::addr_of_mut!(r#a).cast(),
+                        ptr: std::ptr::addr_of_mut!(r#version).cast(),
                         size: std::mem::size_of::<u32>(),
                     }},
                 }},
@@ -122,8 +122,8 @@ pub fn emit(interface: &Interface) -> String {
                 self.0.invoke({OP_VERSION}, args.as_mut_ptr(), crate::object::pack_counts(0, 1, 0, 0))
             }} {{
                 0 => {{
-                    let r#a = unsafe {{ r#a.assume_init() }};
-                    Ok((r#a))
+                    let r#version = unsafe {{ r#version.assume_init() }};
+                    Ok((r#version))
                 }}
                 err => Err(unsafe {{ std::mem::transmute(err) }}),
             }}

--- a/idlc_codegen_rust/src/interface/mod.rs
+++ b/idlc_codegen_rust/src/interface/mod.rs
@@ -108,6 +108,7 @@ pub fn emit(interface: &Interface) -> String {
 
     /// '{ident}' interface at version '{interface_version}'
     impl {ident} {{
+        #[inline]
         pub fn r#{VERSION_FUNC_NAME}(&self) -> Result<(u32), Error> {{
             let mut r#version = std::mem::MaybeUninit::<u32>::uninit();
             let mut args = [

--- a/tests/cpp/impl_base.hpp
+++ b/tests/cpp/impl_base.hpp
@@ -37,13 +37,6 @@ class ImplBase {
                 me->retain();
                 return Object_OK;
             }
-            case Object_OP_version: {
-                if (arg_count != ObjectCounts_pack(0, 1, 0, 0) || args[0].b.size != 4) {
-                    return Object_ERROR_INVALID;
-                }
-                uint32_t *a_ptr = (uint32_t*)args[0].b.ptr;
-                return me->api_version(a_ptr);
-            }
             default:
                 return me->invoke(op, args, arg_count);
         }
@@ -63,11 +56,6 @@ class ImplBase {
         auto old_value = refcount--;
         assert(old_value > 0);
         return old_value == 1;
-    }
-
-    // Auto-generated classes override this function
-    virtual int32_t api_version(uint32_t *a_ptr) {
-      return Object_ERROR_INVALID;
     }
 
    private:


### PR DESCRIPTION
It is better to exclude the implementation of `api_version` from impl_base.hpp for the recently added interface method versioning feature.
impl_base.hpp is a common file among all C++ Mink implementations and as such, it should be a simple as possible. Although we want the `api_version` function to be transparently added to each Mink interface, it was decided that the impl_base.hpp should remain untouched and the changes should reside entirely within the auto-generated header files.

What was previously implemented across impl_base.hpp + Mink C++ header file is now handled entirely within the Mink C++ header file. There are no new function definitions in the implementation with this change.