### PR TITLE
refactor(codegen): params args

### DIFF
--- a/idlc_codegen_c/src/interface/functions/implementation.rs
+++ b/idlc_codegen_c/src/interface/functions/implementation.rs
@@ -295,7 +295,7 @@ pub fn emit(
     let ident = &function.ident;
     let total = counts.total();
 
-    let params = super::signature::iter_to_string(signature.params());
+    let params = signature.params();
 
     let implementation = Implementation::new(function);
 

--- a/idlc_codegen_c/src/interface/functions/invoke.rs
+++ b/idlc_codegen_c/src/interface/functions/invoke.rs
@@ -359,7 +359,7 @@ pub fn emit(
 
     let invoke = Invoke::new(function, is_no_typed_objects);
 
-    let return_idents = super::signature::iter_to_string(signature.return_idents());
+    let return_idents = signature.return_idents();
     let call = format!(r"int32_t r = prefix##{ident}(me{return_idents});");
 
     let counts = format!(

--- a/idlc_codegen_c/src/interface/functions/signature.rs
+++ b/idlc_codegen_c/src/interface/functions/signature.rs
@@ -19,27 +19,6 @@ pub struct Signature {
     is_no_typed_objects: bool,
 }
 
-pub fn iter_to_string(iter: impl Iterator<Item = impl AsRef<str>>) -> String {
-    let mut acc = String::new();
-    for item in iter {
-        acc.push(',');
-        acc.push(' ');
-        acc += item.as_ref();
-    }
-
-    acc
-}
-
-pub fn addition_iter_to_string(iter: impl Iterator<Item = impl AsRef<str>>) -> String {
-    let mut acc = String::new();
-    for item in iter {
-        acc.push('+');
-        acc += item.as_ref();
-    }
-
-    acc
-}
-
 impl Signature {
     pub fn new(
         function: &idlc_mir::Function,
@@ -72,15 +51,33 @@ impl Signature {
         self.input_obj_arg.iter()
     }
 
-    pub fn params(&self) -> impl Iterator<Item = String> + '_ {
+    pub fn param_iter(&self) -> impl Iterator<Item = String> + '_ {
         self.inputs
             .iter()
             .map(|(ident, ty)| format!("{ty} {ident}"))
     }
 
+    pub fn params(&self) -> String {
+        let mut acc = String::new();
+        for ident in self.param_iter() {
+            acc.push_str(", ");
+            acc += ident.as_ref();
+        }
+        acc
+    }
+
     #[inline]
-    pub fn return_idents(&self) -> impl Iterator<Item = &str> {
+    pub fn return_idents_iter(&self) -> impl Iterator<Item = &str> {
         self.outputs.iter().map(|(ident, _)| ident.as_str())
+    }
+
+    pub fn return_idents(&self) -> String {
+        let mut acc = String::new();
+        for ident in self.return_idents_iter() {
+            acc.push_str(", ");
+            acc += ident.as_ref();
+        }
+        acc
     }
 }
 

--- a/idlc_codegen_c/src/interface/functions/signature.rs
+++ b/idlc_codegen_c/src/interface/functions/signature.rs
@@ -75,7 +75,7 @@ impl Signature {
         let mut acc = String::new();
         for ident in self.return_idents_iter() {
             acc.push_str(", ");
-            acc += ident.as_ref();
+            acc += ident;
         }
         acc
     }

--- a/idlc_codegen_cpp/src/interface/functions/implementation.rs
+++ b/idlc_codegen_cpp/src/interface/functions/implementation.rs
@@ -236,11 +236,7 @@ pub fn emit(
     let ident = &function.ident;
     let total = counts.total();
 
-    let mut params =
-        idlc_codegen_c::interface::functions::signature::iter_to_string(signature.params());
-    if !params.is_empty() {
-        params.remove(0);
-    }
+    let params = signature.params();
 
     let implementation = Implementation::new(function);
 

--- a/idlc_codegen_cpp/src/interface/functions/invoke.rs
+++ b/idlc_codegen_cpp/src/interface/functions/invoke.rs
@@ -178,14 +178,8 @@ pub fn emit(
     counts: &idlc_codegen::counts::Counter,
 ) -> String {
     let ident = &function.ident;
-
     let invoke = Invoke::new(function);
-
-    let mut return_idents =
-        idlc_codegen_c::interface::functions::signature::iter_to_string(signature.return_idents());
-    if !return_idents.is_empty() {
-        return_idents.remove(0);
-    }
+    let return_idents = signature.return_idents();
 
     let call = format!("int32_t r = {ident}({return_idents});");
 

--- a/idlc_codegen_cpp/src/interface/functions/signature.rs
+++ b/idlc_codegen_cpp/src/interface/functions/signature.rs
@@ -43,15 +43,23 @@ impl Signature {
         me
     }
 
-    pub fn params(&self) -> impl Iterator<Item = String> + '_ {
+    pub fn param_iter(&self) -> impl Iterator<Item = String> + '_ {
         self.inputs
             .iter()
             .map(|(ident, ty)| format!("{ty} {ident}"))
     }
 
+    pub fn params(&self) -> String {
+        self.param_iter().collect::<Vec<_>>().join(", ")
+    }
+
     #[inline]
-    pub fn return_idents(&self) -> impl Iterator<Item = &str> {
+    pub fn return_idents_iter(&self) -> impl Iterator<Item = &str> {
         self.outputs.iter().map(|(ident, _)| ident.as_str())
+    }
+
+    pub fn return_idents(&self) -> String {
+        self.return_idents_iter().collect::<Vec<_>>().join(", ")
     }
 }
 

--- a/idlc_codegen_cpp/src/interface/mod.rs
+++ b/idlc_codegen_cpp/src/interface/mod.rs
@@ -46,12 +46,7 @@ pub fn emit_interface_impl(interface: &Interface) -> String {
                 idlc_codegen::documentation::DocumentationStyle::C,
             );
             if is_root {
-                let mut params = idlc_codegen_c::interface::functions::signature::iter_to_string(
-                    signature.params(),
-                );
-                if !params.is_empty() {
-                    params.remove(0);
-                }
+                let params = signature.params();
                 func_titles.push_str(&format!(
                     r#"
     virtual int32_t {}({}) = 0;"#,

--- a/idlc_codegen_rust/src/interface/functions/implementation.rs
+++ b/idlc_codegen_rust/src/interface/functions/implementation.rs
@@ -341,7 +341,7 @@ pub fn emit(
 
     let return_idents = super::signature::iter_to_string(signature.return_idents());
     let returns_types = super::signature::iter_to_string(signature.return_types());
-    let params = super::signature::iter_to_string(signature.params());
+    let params = signature.params();
 
     let counts = (
         counts.input_buffers,

--- a/idlc_codegen_rust/src/interface/functions/implementation.rs
+++ b/idlc_codegen_rust/src/interface/functions/implementation.rs
@@ -113,7 +113,10 @@ impl idlc_codegen::functions::ParameterVisitor for Implementation {
         let Some(TransportBuffer { definition, size }) = packer.bi_definition() else {
             unreachable!()
         };
-        let idents = super::signature::iter_to_string(packer.bi_assignment_idents());
+        let idents = packer
+            .bi_assignment_idents()
+            .collect::<Vec<String>>()
+            .join(", ");
         self.initializations.push(format!(
             r#"
             {definition}
@@ -232,7 +235,7 @@ impl idlc_codegen::functions::ParameterVisitor for Implementation {
         let Some(TransportBuffer { definition, size }) = packer.bo_definition() else {
             unreachable!()
         };
-        let idents = super::signature::iter_to_string(packer.bo_idents());
+        let idents = packer.bo_idents().collect::<Vec<String>>().join(", ");
         self.initializations.push(format!(
             r#"
                 {definition}
@@ -339,8 +342,8 @@ pub fn emit(
     let post_call_assignments = implementation.post_call_assignments();
     let args = implementation.args();
 
-    let return_idents = super::signature::iter_to_string(signature.return_idents());
-    let returns_types = super::signature::iter_to_string(signature.return_types());
+    let return_idents = signature.return_idents().collect::<Vec<_>>().join(", ");
+    let returns_types = signature.return_types().collect::<Vec<_>>().join(", ");
     let params = signature.params();
 
     let counts = (

--- a/idlc_codegen_rust/src/interface/functions/invoke.rs
+++ b/idlc_codegen_rust/src/interface/functions/invoke.rs
@@ -111,7 +111,7 @@ impl idlc_codegen::functions::ParameterVisitor for Invoke {
             unreachable!()
         };
         let idx = self.idx();
-        let idents = super::signature::iter_to_string(packer.bi_definition_idents());
+        let idents = packer.bi_definition_idents().collect::<Vec<_>>().join(", ");
         self.pre.push(definition);
         self.pre.push(format!(
             r#"
@@ -146,10 +146,15 @@ impl idlc_codegen::functions::ParameterVisitor for Invoke {
                 "let mut {ident} = std::mem::ManuallyDrop::new(std::ptr::read({ARGS}[{idx}].bi.ptr.cast::<{ty}>()));"
             ));
             for (object, _) in objects {
-                let path = super::signature::idents_to_struct_path(&object);
+                dbg!(&object);
+                let path = object
+                    .iter()
+                    .map(|i| i.to_string())
+                    .collect::<Vec<_>>()
+                    .join(".");
                 let idx = self.idx();
                 self.pre.push(format!(
-                    "std::ptr::write(&mut {ident}{path}, std::mem::transmute_copy(&{ARGS}[{idx}].o));"
+                    "std::ptr::write(&mut {ident}.{path}, std::mem::transmute_copy(&{ARGS}[{idx}].o));"
                 ));
             }
             self.pre.push(format!("let {ident} = &{ident};"))
@@ -253,7 +258,7 @@ impl idlc_codegen::functions::ParameterVisitor for Invoke {
             }}
             "#,
         ));
-        let idents = super::signature::iter_to_string(packer.bo_idents());
+        let idents = packer.bo_idents().collect::<Vec<String>>().join(", ");
         self.post.push(format!(
             r#"
             std::ptr::write({ARGS}[{idx}].b.ptr.cast::<{BO_STRUCT}>(), {BO_STRUCT}({idents}));
@@ -304,8 +309,8 @@ pub fn emit(
     let pre = params.pre();
     let post = params.post();
 
-    let params = super::signature::iter_to_string(signature.param_idents());
-    let returns = super::signature::iter_to_string(signature.return_idents());
+    let params = signature.param_idents().collect::<Vec<_>>().join(", ");
+    let returns = signature.return_idents().collect::<Vec<_>>().join(", ");
 
     format!(
         r#"

--- a/idlc_codegen_rust/src/interface/functions/serialization.rs
+++ b/idlc_codegen_rust/src/interface/functions/serialization.rs
@@ -77,10 +77,13 @@ impl<'a> PackedPrimitives<'a> {
             return None;
         }
 
-        let fields = super::signature::iter_to_string(types.map(|ty| match ty {
-            &Type::Primitive(p) => Cow::Borrowed(change_primitive(p)),
-            Type::SmallStruct(s) => Cow::Owned(namespaced_struct(s)),
-        }));
+        let fields = types
+            .map(|ty| match ty {
+                &Type::Primitive(p) => Cow::Borrowed(change_primitive(p)),
+                Type::SmallStruct(s) => Cow::Owned(namespaced_struct(s)),
+            })
+            .collect::<Vec<_>>()
+            .join(", ");
         let definition = format!(
             r#"
         #[repr(C, packed)]

--- a/idlc_codegen_rust/src/interface/functions/signature.rs
+++ b/idlc_codegen_rust/src/interface/functions/signature.rs
@@ -14,21 +14,6 @@ pub struct Signature {
     outputs: Vec<(String, String)>,
 }
 
-pub fn iter_to_string(iter: impl Iterator<Item = impl AsRef<str>>) -> String {
-    let mut acc = String::new();
-    for item in iter {
-        acc += item.as_ref();
-        acc.push(',');
-    }
-
-    if !acc.is_empty() {
-        // Remove leading commas, this can make single element values a tuple.
-        acc.truncate(acc.len() - 1);
-    }
-
-    acc
-}
-
 pub fn idents_to_struct_path(objects: &[&Ident]) -> String {
     objects
         .iter()

--- a/idlc_codegen_rust/src/interface/functions/signature.rs
+++ b/idlc_codegen_rust/src/interface/functions/signature.rs
@@ -48,7 +48,11 @@ impl Signature {
         self.inputs.iter().map(|(ident, _)| ident.as_str())
     }
 
-    pub fn params(&self) -> impl Iterator<Item = String> + '_ {
+    pub fn params(&self) -> String {
+        self.param_iter().collect::<Vec<String>>().join(", ")
+    }
+
+    pub fn param_iter(&self) -> impl Iterator<Item = String> + '_ {
         self.inputs
             .iter()
             .map(|(ident, ty)| format!("{ident}: {ty}"))

--- a/idlc_codegen_rust/src/interface/functions/traits.rs
+++ b/idlc_codegen_rust/src/interface/functions/traits.rs
@@ -7,7 +7,7 @@ pub fn emit(
     signature: &super::signature::Signature,
 ) -> String {
     let ident = &function.ident;
-    let returns = super::signature::iter_to_string(signature.return_types());
+    let returns = signature.return_types().collect::<Vec<_>>().join(", ");
     let params = signature.params();
     format!(
         r#"

--- a/idlc_codegen_rust/src/interface/functions/traits.rs
+++ b/idlc_codegen_rust/src/interface/functions/traits.rs
@@ -8,7 +8,7 @@ pub fn emit(
 ) -> String {
     let ident = &function.ident;
     let returns = super::signature::iter_to_string(signature.return_types());
-    let params = super::signature::iter_to_string(signature.params());
+    let params = signature.params();
     format!(
         r#"
     {documentation}

--- a/tests/c/header.h
+++ b/tests/c/header.h
@@ -56,6 +56,8 @@ int32_t itest1_release(struct CTest1 *ctx);
 
 int32_t itest1_retain(struct CTest1 *ctx);
 
+int32_t itest1_no_args(struct CTest1 *ctx);
+
 int32_t itest1_test_f1(struct CTest1 *ctx, uint32_t a_val, uint32_t *b_ptr);
 
 int32_t itest1_single_in(struct CTest1 *ctx, uint32_t input_val);

--- a/tests/c/invoke.c
+++ b/tests/c/invoke.c
@@ -86,6 +86,10 @@ int32_t itest1_retain(struct CTest1 *ctx) {
   return Object_OK;
 }
 
+int32_t itest1_no_args(struct CTest1 *ctx) {
+  return Object_OK;
+}
+
 int32_t itest1_test_f1(struct CTest1 *ctx, uint32_t a_val, uint32_t *b_ptr) {
   *b_ptr = a_val + ctx->value;
   return Object_OK;
@@ -359,6 +363,9 @@ int32_t itest3_extra_test3(struct CTest1 *ctx, uint32_t *output_ptr) {
   return Object_OK;
 }
 
+int32_t itest3_no_args(struct CTest1 *ctx) {
+  return itest1_no_args(ctx);
+}
 int32_t itest3_test_f1(struct CTest1 *ctx, uint32_t a_val, uint32_t *b_ptr) {
   return itest1_test_f1(ctx, a_val, b_ptr);
 }

--- a/tests/cpp/main.cpp
+++ b/tests/cpp/main.cpp
@@ -27,6 +27,9 @@ public:
   ITest1Impl(struct c::CTest1 ctest) { this->ctest = ctest; }
   ~ITest1Impl() {}
 
+  int32_t no_args() {
+    return c::itest1_no_args(&this->ctest);
+  }
   int32_t test_f1(uint32_t a_val, uint32_t *b_ptr) {
     return c::itest1_test_f1(&this->ctest, a_val, b_ptr);
   }
@@ -267,6 +270,9 @@ public:
   ~ITest3Impl() {}
   int32_t extra_test3(uint32_t *output_ptr) {
     return c::itest3_extra_test3(&this->ctest, output_ptr);
+  }
+  int32_t no_args() {
+    return c::itest1_no_args(&this->ctest);
   }
   int32_t test_f1(uint32_t a_val, uint32_t *b_ptr) {
     return c::itest1_test_f1(&this->ctest, a_val, b_ptr);

--- a/tests/idl/ITest.idl
+++ b/tests/idl/ITest.idl
@@ -64,6 +64,7 @@ interface ITest1 {
   method test_obj_array_in(in ITest1[3] o_in, out uint32 a);
   method test_obj_array_out(out ITest1[3] out, out uint32 a);
   method objects_in_struct(in ObjInStruct input, out ObjInStruct output);
+  method no_args();
 
   #[version = 1.0]
   method derive_v0(in uint32 a); // the default version attribute should have no effect. Cannot have major version less than 1.

--- a/tests/src/implementation/test1.rs
+++ b/tests/src/implementation/test1.rs
@@ -10,6 +10,10 @@ use crate::interfaces::itest4::{self, IITest4};
 macro_rules! itest1_impl {
     ($impl: ident) => {
         impl IITest1 for $impl {
+            fn no_args(&mut self) -> Result<(), itest1::Error> {
+                Ok(())
+            }
+
             fn test_f1(&mut self, a: u32) -> Result<u32, itest1::Error> {
                 Ok(self.value + a + 1000)
             }


### PR DESCRIPTION
Refactor codegen for C, C++, and Rust to eliminate auxiliary formatting functions in favor of built-in Rust formatting functions, such as `join()`