### PR TITLE
fix: Refactor tests

### DIFF
--- a/idlc_ast_passes/tests/functions.rs
+++ b/idlc_ast_passes/tests/functions.rs
@@ -20,3 +20,30 @@ fn duplicate_params() {
         };",
     );
 }
+
+#[should_panic = "Function `Duplicates::foo` has multiple 'version' attributes: 1.1, 1.2"]
+#[test]
+fn multiple_version_attr() {
+    verify(
+        r"
+        interface Duplicates {
+            #[version = 1.1]
+            #[version = 1.2]
+            method foo();
+        };",
+    );
+}
+
+#[should_panic = "Function `Duplicates::bar` version `1.1` cannot be less than the previous method `1.2`"]
+#[test]
+fn version_attr_not_monotonic() {
+    verify(
+        r"
+        interface Duplicates {
+            #[version = 1.2]
+            method foo();
+            #[version = 1.1]
+            method bar();
+        };",
+    );
+}

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,0 +1,152 @@
+# `idlc_test` — Integration Test Suite
+
+This crate is the end-to-end integration test suite for `idlc`, the MINK IDL
+compiler. It compiles test IDL files through the compiler, exercises the
+generated headers in C, C++, and Rust, and runs a single Rust binary that
+calls interface methods across every combination of language boundary.
+
+## How it works
+
+### Build pipeline (`build.rs`)
+
+The build script drives the entire code-generation and compilation pipeline:
+
+1. **IDL compilation** — `idlc` is invoked on each `.idl` file in `idl/` to
+   produce:
+   - `c/ITest.h`, `c/ITest_invoke.h` — C client proxy macros and server
+     skeleton dispatcher
+   - `cpp/ITest.hpp`, `cpp/ITest_invoke.hpp` — C++ client proxy class and
+     server skeleton base class
+   - `rust/itest1.rs` etc. — Rust trait, proxy struct, and invoke dispatcher,
+     included directly via `include!()` in `src/lib.rs`
+
+2. **C static library** (`c-ffi`) — `c/invoke.c` is compiled with the
+   generated C headers. It provides `create_c_itest1`, `create_c_itest2`, and
+   `create_c_itest3` as `extern "C"` symbols.
+
+3. **C++ static library** (`cpp-ffi`) — `cpp/main.cpp` is compiled with both
+   the generated C++ headers and the C headers (for shared struct definitions).
+   It provides `create_cpp_itest1`, `create_cpp_itest2`, and
+   `create_cpp_itest3` as `extern "C"` symbols.
+
+4. **Rust library** — `src/lib.rs` links the two static libraries and exposes
+   `c::create_itest{1,2,3}` and `cpp::create_itest{1,2,3}` as unsafe FFI
+   wrappers, along with native Rust implementations in `src/implementation/`.
+
+### Object model
+
+All three language backends share a common `Object` ABI:
+
+```c
+typedef struct {
+    int32_t (*invoke)(void *ctx, ObjectOp op, ObjectArg *args, ObjectCounts k);
+    void *ctx;
+} Object;
+```
+
+A `retain`/`release` lifecycle is managed through the `OP_RETAIN`/`OP_RELEASE`
+operations dispatched through `invoke`. The generated client-side proxy (C
+macros, C++ `ProxyBase`, Rust `ITest1` struct) holds an `Object` and
+translates typed method calls into `invoke(op, args, counts)` calls.
+
+### Interfaces under test
+
+#### `ITest.idl` — core test interfaces
+
+- **`ITest1`** — the primary interface under test, with 25+ methods covering:
+  - Scalar in/out primitives (`single_in`, `single_out`, `add_1000`)
+  - Buffer arguments alongside scalar primitives (`single_primitive_in/out`,
+    `multiple_primitive`)
+  - Struct arguments by value (`in_struct`, `out_struct`, `in_small_struct`,
+    `out_small_struct`, `bundled_with_unbundled`, `primitive_plus_struct_*`)
+  - Arrays of structs (`struct_array_in/out`, `primitive_array_in_struct`)
+  - Arrays of interface objects (`test_obj_array_in/out`)
+  - Structs containing interface objects (`objects_in_struct`)
+  - An optional/unimplemented method (`unimplemented`)
+  - Versioned methods with `#[version]` attributes (`derive_v*`)
+
+- **`ITest2`** — a single-method orchestrator: `entrypoint(in ITest1 o)`
+  receives an `ITest1` object and exhaustively exercises its API.
+
+#### `ITest3.idl` — inheritance test interfaces
+
+- **`ITest3`** — extends `ITest1` with one additional method (`extra_test3`).
+  Used to verify that the compiler correctly emits inherited method dispatchers
+  and that the default API version is `1.0.0` when no `#[version]` attributes
+  are present.
+
+- **`ITest4`** — extends `ITest3`, verifying multi-level inheritance.
+
+### Language implementations
+
+Each language provides three implementations that mirror each other:
+
+| Symbol                     | Language | Source                        |
+|----------------------------|----------|-------------------------------|
+| `create_c_itest1(value)`   | C        | `c/invoke.c`                  |
+| `create_c_itest2()`        | C        | `c/invoke.c`                  |
+| `create_c_itest3()`        | C        | `c/invoke.c`                  |
+| `create_cpp_itest1(value)` | C++      | `cpp/main.cpp`                |
+| `create_cpp_itest2()`      | C++      | `cpp/main.cpp`                |
+| `create_cpp_itest3()`      | C++      | `cpp/main.cpp`                |
+| `implementation::ITest1`   | Rust     | `src/implementation/test1.rs` |
+| `implementation::ITest2`   | Rust     | `src/implementation/test2.rs` |
+| `implementation::ITest3`   | Rust     | `src/implementation/test1.rs` |
+
+The C++ implementations in `cpp/main.cpp` delegate their method bodies to the
+C implementations in `c/invoke.c` via the shared `c::` namespace, so the
+actual logic lives in one place. The Rust implementations in
+`src/implementation/` are independent.
+
+All three `ITest1` implementations share the same test fixtures and invariants:
+`TRUTH` (a `Collection`) and `TRUTH2` (a `SingleEncapsulated`). The helper
+function `test_singular_object` (C/C++ in `c/invoke.c`, Rust in
+`src/implementation/mod.rs`) exhaustively exercises all scalar, struct, and
+array methods on a single `ITest1` object, including an `api_version` check
+that asserts `2.0.0`.
+
+### Test harness (`tests/`)
+
+The Rust test harness in `tests/` exercises all 9 combinations of ITest2
+implementor × ITest1 implementor across the three languages:
+
+| Test file                | ITest2 (caller) | ITest1 (callee) |
+|--------------------------|-----------------|-----------------|
+| `tests/main.rs::to_c`    | Rust            | C               |
+| `tests/main.rs::to_cpp`  | Rust            | C++             |
+| `tests/main.rs::to_rust` | Rust            | Rust            |
+| `tests/c.rs::to_c`       | C               | C               |
+| `tests/c.rs::to_cpp`     | C               | C++             |
+| `tests/c.rs::to_rust`    | C               | Rust            |
+| `tests/cpp.rs::to_c`     | C++             | C               |
+| `tests/cpp.rs::to_cpp`   | C++             | C++             |
+| `tests/cpp.rs::to_rust`  | C++             | Rust            |
+
+`tests/main.rs` additionally contains thread-safety tests
+(`implementation_and_invoke_sync` and `implementation_and_invoke_send`) that
+run the Rust→Rust path from 10 concurrent threads.
+
+Each `to_c` test also constructs an `ITest3` object (same language) and
+verifies that the API version defaults to `1.0.0` when no `#[version]`
+attributes are present in the IDL.
+
+### Running the tests
+
+```sh
+# Build idlc first (required by the test build script)
+cargo build -p idlc
+
+# Run all integration tests
+cargo test -p idlc_test
+```
+
+The `IDLC` environment variable can point to an alternate compiler binary:
+
+```sh
+IDLC=/path/to/idlc cargo test -p idlc_test
+```
+
+### What is NOT tested
+
+- **Java** — Java code generation exists in `idlc` but Java compilation is not
+  yet wired into this test suite.

--- a/tests/c/header.h
+++ b/tests/c/header.h
@@ -58,7 +58,7 @@ int32_t itest1_retain(struct CTest1 *ctx);
 
 int32_t itest1_no_args(struct CTest1 *ctx);
 
-int32_t itest1_test_f1(struct CTest1 *ctx, uint32_t a_val, uint32_t *b_ptr);
+int32_t itest1_add_1000(struct CTest1 *ctx, uint32_t a_val, uint32_t *b_ptr);
 
 int32_t itest1_single_in(struct CTest1 *ctx, uint32_t input_val);
 

--- a/tests/c/invoke.c
+++ b/tests/c/invoke.c
@@ -35,6 +35,35 @@ int32_t test_singular_object(Object itest1) {
   ASSERT(flag2 == SUCCESS_FLAG);
   CHECK_OK(ITest1_bundled_with_unbundled(itest1, &single_encapsulated,
                                          SUCCESS_FLAG, &TRUTH));
+  CHECK_OK(ITest1_in_struct(itest1, &TRUTH));
+  CHECK_OK(ITest1_in_small_struct(itest1, &TRUTH2));
+  {
+    uint32_t b = 0;
+    CHECK_OK(ITest1_add_1000(itest1, 5, &b));
+    ASSERT(b == 1005);
+  }
+  {
+    Collection s_in[2] = {TRUTH, TRUTH};
+    CHECK_OK(ITest1_struct_array_in(itest1, s_in, 2));
+  }
+  {
+    Collection s_out[2] = {0};
+    size_t s_out_lenout = 0;
+    CHECK_OK(ITest1_struct_array_out(itest1, s_out, 2, &s_out_lenout));
+    ASSERT(s_out_lenout == 2);
+    ASSERT(memcmp(&s_out[0], &TRUTH, sizeof(TRUTH)) == 0);
+    ASSERT(memcmp(&s_out[1], &TRUTH, sizeof(TRUTH)) == 0);
+  }
+  {
+    ArrInStruct arr = {0};
+    uint32_t magic = 0;
+    CHECK_OK(ITest1_primitive_array_in_struct(itest1, &arr, &magic));
+    ASSERT(arr.a[0] == 7 && arr.a[1] == 8);
+    ASSERT(arr.c[0].a == 9 && arr.c[0].b == 7);
+    ASSERT(arr.c[1].a == 8 && arr.c[1].b == 9);
+    ASSERT(arr.d == SUCCESS_FLAG);
+    ASSERT(magic == SUCCESS_FLAG);
+  }
   {
     uint32_t out = 0;
     CHECK_OK(ITest1_single_out(itest1, &out));
@@ -53,6 +82,16 @@ int32_t test_singular_object(Object itest1) {
         ITest1_primitive_plus_struct_out(itest1, &single_encapsulated, &out));
     ASSERT(out == SUCCESS_FLAG);
     ASSERT(single_encapsulated.inner == SUCCESS_FLAG);
+  }
+  {
+    Collection out = {0};
+    CHECK_OK(ITest1_out_struct(itest1, &out));
+    ASSERT(memcmp(&out, &TRUTH, sizeof(TRUTH)) == 0);
+  }
+  {
+    SingleEncapsulated out = {0};
+    CHECK_OK(ITest1_out_small_struct(itest1, &out));
+    ASSERT(memcmp(&out, &TRUTH2, sizeof(TRUTH2)) == 0);
   }
   {
     uint32_t out = 0;
@@ -90,8 +129,8 @@ int32_t itest1_no_args(struct CTest1 *ctx) {
   return Object_OK;
 }
 
-int32_t itest1_test_f1(struct CTest1 *ctx, uint32_t a_val, uint32_t *b_ptr) {
-  *b_ptr = a_val + ctx->value;
+int32_t itest1_add_1000(struct CTest1 *ctx, uint32_t a_val, uint32_t *b_ptr) {
+  *b_ptr = a_val + 1000;
   return Object_OK;
 }
 
@@ -354,9 +393,17 @@ ITest2_DEFINE_INVOKE(itest2_invoke, itest2_, void *);
 Object create_c_itest2() { return (Object){itest2_invoke, NULL}; }
 
 
-int32_t itest3_release(void *ctx) { return Object_OK; }
+int32_t itest3_release(struct CTest1 *ctx) {
+  if (--ctx->refs == 0) {
+    free(ctx);
+  }
+  return Object_OK;
+}
 
-int32_t itest3_retain(void *ctx) { return Object_OK; }
+int32_t itest3_retain(struct CTest1 *ctx) {
+  ctx->refs++;
+  return Object_OK;
+}
 
 int32_t itest3_extra_test3(struct CTest1 *ctx, uint32_t *output_ptr) {
   *output_ptr = 0xdead;
@@ -366,8 +413,8 @@ int32_t itest3_extra_test3(struct CTest1 *ctx, uint32_t *output_ptr) {
 int32_t itest3_no_args(struct CTest1 *ctx) {
   return itest1_no_args(ctx);
 }
-int32_t itest3_test_f1(struct CTest1 *ctx, uint32_t a_val, uint32_t *b_ptr) {
-  return itest1_test_f1(ctx, a_val, b_ptr);
+int32_t itest3_add_1000(struct CTest1 *ctx, uint32_t a_val, uint32_t *b_ptr) {
+  return itest1_add_1000(ctx, a_val, b_ptr);
 }
 
 int32_t itest3_single_in(struct CTest1 *ctx, uint32_t input_val) {
@@ -462,12 +509,12 @@ int32_t itest3_well_documented_method(struct CTest1 *ctx, uint32_t foo_val,
 
 int32_t itest3_test_obj_array_in(struct CTest1 *ctx,
                                  const Object (*o_in_ptr)[3], uint32_t *a_ptr) {
-  return Object_OK;
+  return itest1_test_obj_array_in(ctx, o_in_ptr, a_ptr);
 }
 
 int32_t itest3_test_obj_array_out(struct CTest1 *ctx, Object (*o_ptr)[3],
                                   uint32_t *a_ptr) {
-  return Object_OK;
+  return itest1_test_obj_array_out(ctx, o_ptr, a_ptr);
 }
 
 int32_t itest3_objects_in_struct(struct CTest1 *ctx, const ObjInStruct *input,
@@ -498,4 +545,12 @@ int32_t itest3_derive_v2p2(struct CTest1 *ctx, uint32_t a_val) {
 
 ITest3_DEFINE_INVOKE(itest3_invoke, itest3_, struct CTest1 *);
 
-Object create_c_itest3() { return (Object){itest3_invoke, NULL}; }
+Object create_c_itest3() {
+  struct CTest1 *ctx = (struct CTest1 *)malloc(sizeof(struct CTest1));
+  if (!ctx)
+    return Object_NULL;
+
+  ctx->refs = 1;
+  ctx->value = 0;
+  return (Object){itest3_invoke, ctx};
+}

--- a/tests/c/invoke.c
+++ b/tests/c/invoke.c
@@ -60,7 +60,7 @@ int32_t test_singular_object(Object itest1) {
     ASSERT(out == SUCCESS_FLAG);
   }
   {
-    // Check for version against typed and generic Objects
+    // Check for version against typed Objects
     uint32_t version = 0;
     CHECK_OK(ITest1_api_version(itest1, &version));
     uint32_t major = (version >> ITest1_MAJOR_SHIFT) & ITest1_MAJOR_MASK;

--- a/tests/cpp/main.cpp
+++ b/tests/cpp/main.cpp
@@ -36,8 +36,8 @@ public:
   int32_t no_args() {
     return c::itest1_no_args(&this->ctest);
   }
-  int32_t test_f1(uint32_t a_val, uint32_t *b_ptr) {
-    return c::itest1_test_f1(&this->ctest, a_val, b_ptr);
+  int32_t add_1000(uint32_t a_val, uint32_t *b_ptr) {
+    return c::itest1_add_1000(&this->ctest, a_val, b_ptr);
   }
   int32_t in_struct(const Collection &input_ref) {
     return c::itest1_in_struct(&this->ctest, (const c::Collection *)(&input_ref));
@@ -221,6 +221,35 @@ public:
     ASSERT(flag2 == SUCCESS_FLAG);
     CHECK_OK(o.bundled_with_unbundled(single_encapsulated,
                                       SUCCESS_FLAG, TRUTH));
+    CHECK_OK(o.in_struct(TRUTH));
+    CHECK_OK(o.in_small_struct({.inner = 0}));
+    {
+      uint32_t b = 0;
+      CHECK_OK(o.add_1000(5, &b));
+      ASSERT(b == 1005);
+    }
+    {
+      Collection s_in[2] = {TRUTH, TRUTH};
+      CHECK_OK(o.struct_array_in(s_in, 2));
+    }
+    {
+      Collection s_out[2] = {};
+      size_t s_out_lenout = 0;
+      CHECK_OK(o.struct_array_out(s_out, 2, &s_out_lenout));
+      ASSERT(s_out_lenout == 2);
+      ASSERT(memcmp(&s_out[0], &TRUTH, sizeof(TRUTH)) == 0);
+      ASSERT(memcmp(&s_out[1], &TRUTH, sizeof(TRUTH)) == 0);
+    }
+    {
+      ArrInStruct arr = {};
+      uint32_t magic = 0;
+      CHECK_OK(o.primitive_array_in_struct(arr, &magic));
+      ASSERT(arr.a[0] == 7 && arr.a[1] == 8);
+      ASSERT(arr.c[0].a == 9 && arr.c[0].b == 7);
+      ASSERT(arr.c[1].a == 8 && arr.c[1].b == 9);
+      ASSERT(arr.d == SUCCESS_FLAG);
+      ASSERT(magic == SUCCESS_FLAG);
+    }
     {
       uint32_t out = 0;
       CHECK_OK(o.single_out(&out));
@@ -239,6 +268,16 @@ public:
         o.primitive_plus_struct_out(single_encapsulated, &out));
     ASSERT(out == SUCCESS_FLAG);
     ASSERT(single_encapsulated.inner == SUCCESS_FLAG);
+  }
+  {
+    Collection out = {};
+    CHECK_OK(o.out_struct(out));
+    ASSERT(memcmp(&out, &TRUTH, sizeof(TRUTH)) == 0);
+  }
+  {
+    SingleEncapsulated out = {};
+    CHECK_OK(o.out_small_struct(out));
+    ASSERT(out.inner == 0);
   }
   {
     uint32_t out = 0;
@@ -301,15 +340,6 @@ public:
     Object_ASSIGN_NULL(output_struct.second_obj);
     Object_ASSIGN_NULL(output_struct.should_be_empty);
 
-    uint32_t version = 0;
-    CHECK_OK(o.api_version(&version));
-    uint32_t major = (version >> ITest1::MAJOR_SHIFT) & ITest1::MAJOR_MASK;
-    uint32_t minor = (version >> ITest1::MINOR_SHIFT) & ITest1::MINOR_MASK;
-    uint32_t patch =  version                         & ITest1::PATCH_MASK;
-    ASSERT(major == 2);
-    ASSERT(minor == 0);
-    ASSERT(patch == 0);
-
     return Object_OK;
   }
 };
@@ -334,8 +364,8 @@ public:
   int32_t no_args() {
     return c::itest1_no_args(&this->ctest);
   }
-  int32_t test_f1(uint32_t a_val, uint32_t *b_ptr) {
-    return c::itest1_test_f1(&this->ctest, a_val, b_ptr);
+  int32_t add_1000(uint32_t a_val, uint32_t *b_ptr) {
+    return c::itest1_add_1000(&this->ctest, a_val, b_ptr);
   }
   int32_t in_struct(const Collection &input_ref) {
     return c::itest1_in_struct(&this->ctest, (const c::Collection *)(&input_ref));

--- a/tests/cpp/main.cpp
+++ b/tests/cpp/main.cpp
@@ -17,6 +17,12 @@ namespace c {
 #include "../c/header.h"
 }
 
+const Collection TRUTH = {
+    .a = 0,
+    .b = 1,
+    .c = 2,
+    .d = 3,
+};
 
 extern "C" {
 Object create_cpp_itest1(uint32_t value);
@@ -193,9 +199,63 @@ Object create_cpp_itest1(uint32_t value) {
 class ITest2Impl : public ITest2ImplBase {
 public:
   int32_t entrypoint(ITest1 &o) {
-    const Object itest1 = o.get();
-    ASSERT(!Object_isNull(itest1));
-    CHECK_OK(c::test_singular_object(itest1));
+    if (o.isNull()) {
+      return Object_ERROR_BADOBJ;
+    }
+    uint8_t empty[] = {};
+    size_t lenout = 0;
+    ProxyBase empty_o = ProxyBase();
+    uint16_t flag1 = 0;
+    uint64_t flag2 = 0;
+    const SingleEncapsulated single_encapsulated = {.inner = SUCCESS_FLAG};
+
+    CHECK_OK(o.single_in(SUCCESS_FLAG));
+    CHECK_OK(o.single_primitive_in(empty, sizeof(empty), empty,
+                                        sizeof(empty), &lenout, SUCCESS_FLAG));
+    CHECK_OK(o.primitive_plus_struct_in(single_encapsulated,
+                                             SUCCESS_FLAG));
+    CHECK_OK(o.multiple_primitive(empty, sizeof(empty), empty, sizeof(empty), &lenout,
+                                  SUCCESS_FLAG, &flag1, empty_o, empty_o, SUCCESS_FLAG, &flag2,
+                                  empty, sizeof(empty), &lenout));
+    ASSERT(flag1 == SUCCESS_FLAG);
+    ASSERT(flag2 == SUCCESS_FLAG);
+    CHECK_OK(o.bundled_with_unbundled(single_encapsulated,
+                                      SUCCESS_FLAG, TRUTH));
+    {
+      uint32_t out = 0;
+      CHECK_OK(o.single_out(&out));
+      ASSERT(out == SUCCESS_FLAG);
+  }
+  {
+    uint32_t out = 0;
+    CHECK_OK(o.single_primitive_out(empty, sizeof(empty), empty,
+                                         sizeof(empty), &lenout, &out));
+    ASSERT(out == SUCCESS_FLAG);
+  }
+  {
+    SingleEncapsulated single_encapsulated = {0};
+    uint32_t out = 0;
+    CHECK_OK(
+        o.primitive_plus_struct_out(single_encapsulated, &out));
+    ASSERT(out == SUCCESS_FLAG);
+    ASSERT(single_encapsulated.inner == SUCCESS_FLAG);
+  }
+  {
+    uint32_t out = 0;
+    CHECK_OK(o.well_documented_method(SUCCESS_FLAG, &out));
+    ASSERT(out == SUCCESS_FLAG);
+  }
+  {
+    // Check for version against typed Objects
+    uint32_t version = 0;
+    CHECK_OK(o.api_version(&version));
+    uint32_t major = (version >> ITest1::MAJOR_SHIFT) & ITest1::MAJOR_MASK;
+    uint32_t minor = (version >> ITest1::MINOR_SHIFT) & ITest1::MINOR_MASK;
+    uint32_t patch =  version                         & ITest1::PATCH_MASK;
+    ASSERT(major == 2);
+    ASSERT(minor == 0);
+    ASSERT(patch == 0);
+  }
 
     ITest1 objects[3] = {create_cpp_itest1(1), Object_NULL,
                               create_cpp_itest1(2)};

--- a/tests/idl/ITest.idl
+++ b/tests/idl/ITest.idl
@@ -40,7 +40,7 @@ interface ITest1 {
   error CUSTOM_ME_ARE_TWO;
   error MISMATCH;
 
-  method test_f1(in uint32 a, out uint32 b);
+  method add_1000(in uint32 a, out uint32 b);
   method in_struct(in Collection input);
   method out_struct(out Collection output);
   method in_small_struct(in SingleEncapsulated input);

--- a/tests/src/implementation/mod.rs
+++ b/tests/src/implementation/mod.rs
@@ -17,7 +17,7 @@ mod test2;
 pub use test1::{ITest1, ITest3};
 pub use test2::ITest2;
 
-fn test_singlular_object(
+fn test_singular_object(
     o: Option<&crate::interfaces::itest1::ITest1>,
 ) -> Result<(), crate::object::Error> {
     use crate::interfaces::itest::*;
@@ -63,6 +63,23 @@ fn test_singlular_object(
         ),
         Ok(())
     );
+    assert_eq!(o.in_struct(&TRUTH), Ok(()));
+    assert_eq!(o.in_small_struct(&TRUTH2), Ok(()));
+    assert_eq!(o.add_1000(5), Ok(1005));
+    assert_eq!(o.struct_array_in(&[TRUTH, TRUTH]), Ok(()));
+    let zeroed = Collection { a: 0, b: 0, c: 0, d: 0 };
+    let mut s_out = [zeroed; 2];
+    let mut s_out_lenout = 0usize;
+    assert_eq!(o.struct_array_out(&mut s_out, &mut s_out_lenout), Ok(()));
+    assert_eq!(s_out_lenout, 2);
+    assert_eq!(s_out[0], TRUTH);
+    assert_eq!(s_out[1], TRUTH);
+    let (arr, magic) = o.primitive_array_in_struct().unwrap();
+    assert_eq!(arr.a, [7, 8]);
+    assert_eq!(arr.c[0], crate::interfaces::itest::F2 { a: 9, b: 7 });
+    assert_eq!(arr.c[1], crate::interfaces::itest::F2 { a: 8, b: 9 });
+    assert_eq!(arr.d, SUCCESS_FLAG as u16);
+    assert_eq!(magic, SUCCESS_FLAG);
 
     assert_eq!(o.single_out(), Ok(SUCCESS_FLAG));
     assert_eq!(
@@ -78,6 +95,8 @@ fn test_singlular_object(
             SUCCESS_FLAG
         ))
     );
+    assert_eq!(o.out_struct(), Ok(TRUTH));
+    assert_eq!(o.out_small_struct(), Ok(TRUTH2));
 
     assert_eq!(o.well_documented_method(SUCCESS_FLAG), Ok(SUCCESS_FLAG));
 

--- a/tests/src/implementation/test1.rs
+++ b/tests/src/implementation/test1.rs
@@ -5,7 +5,6 @@ use super::{TRUTH, TRUTH2};
 use crate::interfaces::itest::{self, ArrInStruct, SingleEncapsulated, F2, SUCCESS_FLAG};
 use crate::interfaces::itest1::{self, IITest1};
 use crate::interfaces::itest3::{self, IITest3};
-use crate::interfaces::itest4::{self, IITest4};
 
 macro_rules! itest1_impl {
     ($impl: ident) => {
@@ -299,16 +298,4 @@ macro_rules! generate_itest3_impl {
 
 generate_itest1_impl!(ITest1);
 
-generate_itest1_impl!(ITest3);
-impl IITest3 for ITest3 {
-    fn r#extra_test3(&mut self) -> Result<u32, itest3::Error> {
-        Ok(SUCCESS_FLAG)
-    }
-}
-
-generate_itest3_impl!(ITest4);
-impl IITest4 for ITest4 {
-    fn r#extra_test4(&mut self) -> Result<u32, itest4::Error> {
-        Ok(SUCCESS_FLAG)
-    }
-}
+generate_itest3_impl!(ITest3);

--- a/tests/src/implementation/test1.rs
+++ b/tests/src/implementation/test1.rs
@@ -14,8 +14,8 @@ macro_rules! itest1_impl {
                 Ok(())
             }
 
-            fn test_f1(&mut self, a: u32) -> Result<u32, itest1::Error> {
-                Ok(self.value + a + 1000)
+            fn add_1000(&mut self, a: u32) -> Result<u32, itest1::Error> {
+                Ok(a + 1000)
             }
 
             fn in_struct(
@@ -134,7 +134,7 @@ macro_rules! itest1_impl {
                     ArrInStruct {
                         a: [7, 8],
                         c: [F2 { a: 9, b: 7 }, F2 { a: 8, b: 9 }],
-                        d: 7,
+                        d: SUCCESS_FLAG as u16,
                     },
                     SUCCESS_FLAG,
                 ))
@@ -192,7 +192,7 @@ macro_rules! itest1_impl {
                 o_in: &[Option<crate::interfaces::itest1::ITest1>; 3],
             ) -> Result<u32, itest1::Error> {
                 for o in o_in.iter().filter(|o| o.is_some()) {
-                    assert_eq!(super::test_singlular_object(o.as_ref()), Ok(()));
+                    assert_eq!(super::test_singular_object(o.as_ref()), Ok(()));
                 }
 
                 Ok(SUCCESS_FLAG)
@@ -216,11 +216,11 @@ macro_rules! itest1_impl {
                 r#input: &crate::interfaces::itest::r#ObjInStruct,
             ) -> Result<crate::interfaces::itest::r#ObjInStruct, itest1::Error> {
                 assert_eq!(
-                    super::test_singlular_object(input.first_obj.as_ref()),
+                    super::test_singular_object(input.first_obj.as_ref()),
                     Ok(())
                 );
                 assert_eq!(
-                    super::test_singlular_object(input.second_obj.as_ref()),
+                    super::test_singular_object(input.second_obj.as_ref()),
                     Ok(())
                 );
                 assert!(input.should_be_empty.is_none());

--- a/tests/src/implementation/test2.rs
+++ b/tests/src/implementation/test2.rs
@@ -22,7 +22,7 @@ impl IITest2 for ITest2 {
         &mut self,
         o: Option<&crate::interfaces::itest1::ITest1>,
     ) -> Result<(), itest2::Error> {
-        assert_eq!(super::test_singlular_object(o), Ok(()));
+        assert_eq!(super::test_singular_object(o), Ok(()));
         let o = o.unwrap();
         let objects: [Option<crate::interfaces::itest1::ITest1>; 3] = [
             Some(super::ITest1::new(1).into()),
@@ -33,7 +33,7 @@ impl IITest2 for ITest2 {
         let (objects, flag) = o.test_obj_array_out().unwrap();
         assert_eq!(flag, SUCCESS_FLAG);
         for object in objects {
-            assert_eq!(super::test_singlular_object(object.as_ref()), Ok(()));
+            assert_eq!(super::test_singular_object(object.as_ref()), Ok(()));
         }
 
         const VALID_PS: [u32; 4] = [SUCCESS_FLAG; 4];
@@ -50,9 +50,9 @@ impl IITest2 for ITest2 {
         assert_eq!(output.p1, VALID_PS);
         assert_eq!(output.p2, VALID_PS);
         assert_eq!(output.p3, VALID_PS);
-        super::test_singlular_object(output.first_obj.as_ref()).unwrap();
+        super::test_singular_object(output.first_obj.as_ref()).unwrap();
         assert_eq!(output.should_be_empty, None);
-        super::test_singlular_object(output.second_obj.as_ref()).unwrap();
+        super::test_singular_object(output.second_obj.as_ref()).unwrap();
 
         Ok(())
     }

--- a/tests/tests/c.rs
+++ b/tests/tests/c.rs
@@ -4,24 +4,35 @@
 #![cfg(not(miri))]
 
 use idlc_test::{
-    c::{create_itest1, create_itest2, create_itest3},
+    c, cpp,
     implementation,
     interfaces::itest2::ITest2,
     interfaces::itest3::IDLVersion,
 };
 
+// The Rust test harness requires that we directly interface with Rust object
+// only. However, underneath each of these, we can instantiate stub/proxy
+// objects from each of the supported languages.
+
+// The following tests all start from a C proxy and invoke to a different
+// server/skeleton backend. That way we ensure that we are covering all of the
+// possible combinations. Of course there is redundancy with other tests but
+// this way we get better code coverage.
 #[test]
-fn implementation() {
-    let c_wrapper = unsafe { create_itest2().unwrap() };
+fn to_c() {
+    // Rust wrapper around ITest2 implemented in invoke.c
+    let c_itest2 = unsafe { c::create_itest2().unwrap() };
+    // ITest1 Rust object, implemented in test1.rs
     let input = implementation::ITest1::default().into();
-    assert_eq!(c_wrapper.entrypoint(Some(&input)), Ok(()));
-    let c_wrapper_itest3 = unsafe { create_itest3().unwrap() };
-    assert_eq!(c_wrapper_itest3.single_in(0xdead), Ok(()));
+    // ITest2 object tests ITest1 interface
+    assert_eq!(c_itest2.entrypoint(Some(&input)), Ok(()));
+    let c_itest3 = unsafe { c::create_itest3().unwrap() };
+    assert_eq!(c_itest3.single_in(0xdead), Ok(()));
     {
         // Test that an IDL with no method attributes defaults to 1.0
         let expected = IDLVersion::new(1,0,0);
         let expected_val: u32 = expected.into();
-        assert_eq!(c_wrapper_itest3.api_version(), Ok(expected_val));
+        assert_eq!(c_itest3.api_version(), Ok(expected_val));
         assert_eq!(1, expected.major());
         assert_eq!(0, expected.minor());
         assert_eq!(0, expected.patch());
@@ -29,8 +40,17 @@ fn implementation() {
 }
 
 #[test]
-fn invoke() {
-    let rust_wrapper: ITest2 = implementation::ITest2::new().into();
-    let input = unsafe { create_itest1(Default::default()).unwrap() };
-    assert_eq!(rust_wrapper.entrypoint(Some(&input)), Ok(()));
+fn to_cpp() {
+    // Rust wrapper around ITest2 implemented in invoke.c
+    let c_itest2 = unsafe { c::create_itest2().unwrap() };
+    let cpp_itest1 = unsafe { cpp::create_itest1(0).unwrap() };
+    assert_eq!(c_itest2.entrypoint(Some(&cpp_itest1)), Ok(()));
+}
+
+#[test]
+fn to_rust() {
+    // Rust wrapper around ITest2 implemented in invoke.c
+    let c_itest2 = unsafe { c::create_itest2().unwrap() };
+    let rust_itest1: idlc_test::interfaces::itest1::ITest1 = implementation::ITest1::default().into();
+    assert_eq!(c_itest2.entrypoint(Some(&rust_itest1)), Ok(()));
 }

--- a/tests/tests/c.rs
+++ b/tests/tests/c.rs
@@ -6,51 +6,47 @@
 use idlc_test::{
     c, cpp,
     implementation,
-    interfaces::itest2::ITest2,
     interfaces::itest3::IDLVersion,
 };
 
-// The Rust test harness requires that we directly interface with Rust object
-// only. However, underneath each of these, we can instantiate stub/proxy
-// objects from each of the supported languages.
+// The following tests start from a C ITest2 implementation (invoke.c) and
+// invoke every combination of ITest1 backend to verify cross-language FFI.
 
-// The following tests all start from a C proxy and invoke to a different
-// server/skeleton backend. That way we ensure that we are covering all of the
-// possible combinations. Of course there is redundancy with other tests but
-// this way we get better code coverage.
 #[test]
 fn to_c() {
-    // Rust wrapper around ITest2 implemented in invoke.c
+    // ITest2 implemented in C (invoke.c)
     let c_itest2 = unsafe { c::create_itest2().unwrap() };
-    // ITest1 Rust object, implemented in test1.rs
-    let input = implementation::ITest1::default().into();
-    // ITest2 object tests ITest1 interface
-    assert_eq!(c_itest2.entrypoint(Some(&input)), Ok(()));
+    // ITest1 implemented in C (invoke.c)
+    let c_itest1 = unsafe { c::create_itest1(0).unwrap() };
+    assert_eq!(c_itest2.entrypoint(Some(&c_itest1)), Ok(()));
+
+    // ITest3 (extends ITest1) implemented in C — verify version defaults to 1.0
+    // when no method attributes are specified in the IDL
     let c_itest3 = unsafe { c::create_itest3().unwrap() };
     assert_eq!(c_itest3.single_in(0xdead), Ok(()));
-    {
-        // Test that an IDL with no method attributes defaults to 1.0
-        let expected = IDLVersion::new(1,0,0);
-        let expected_val: u32 = expected.into();
-        assert_eq!(c_itest3.api_version(), Ok(expected_val));
-        assert_eq!(1, expected.major());
-        assert_eq!(0, expected.minor());
-        assert_eq!(0, expected.patch());
-    }
+    let expected = IDLVersion::new(1, 0, 0);
+    let expected_val: u32 = expected.into();
+    assert_eq!(c_itest3.api_version(), Ok(expected_val));
+    assert_eq!(1, expected.major());
+    assert_eq!(0, expected.minor());
+    assert_eq!(0, expected.patch());
 }
 
 #[test]
 fn to_cpp() {
-    // Rust wrapper around ITest2 implemented in invoke.c
+    // ITest2 implemented in C (invoke.c)
     let c_itest2 = unsafe { c::create_itest2().unwrap() };
+    // ITest1 implemented in C++ (main.cpp)
     let cpp_itest1 = unsafe { cpp::create_itest1(0).unwrap() };
     assert_eq!(c_itest2.entrypoint(Some(&cpp_itest1)), Ok(()));
 }
 
 #[test]
 fn to_rust() {
-    // Rust wrapper around ITest2 implemented in invoke.c
+    // ITest2 implemented in C (invoke.c)
     let c_itest2 = unsafe { c::create_itest2().unwrap() };
-    let rust_itest1: idlc_test::interfaces::itest1::ITest1 = implementation::ITest1::default().into();
+    // ITest1 implemented in Rust (implementation/test1.rs)
+    let rust_itest1: idlc_test::interfaces::itest1::ITest1 =
+        implementation::ITest1::default().into();
     assert_eq!(c_itest2.entrypoint(Some(&rust_itest1)), Ok(()));
 }

--- a/tests/tests/cpp.rs
+++ b/tests/tests/cpp.rs
@@ -6,69 +6,47 @@
 use idlc_test::{
     c, cpp,
     implementation,
-    interfaces::itest2::ITest2,
+    interfaces::itest1::IDLVersion,
 };
 
-// The Rust test harness requires that we directly interface with Rust object
-// only. However, underneath each of these, we can instantiate stub/proxy
-// objects from each of the supported languages.
+// The following tests start from a C++ ITest2 implementation (main.cpp) and
+// invoke every combination of ITest1 backend to verify cross-language FFI.
 
-// The following tests all start from a C proxy and invoke to a different
-// server/skeleton backend. That way we ensure that we are covering all of the
-// possible combinations. Of course there is redundancy with other tests but
-// this way we get better code coverage.
 #[test]
 fn to_c() {
-    // ITest2 Rust wrapper around C++ impl of ITest2 in main.cpp
+    // ITest2 implemented in C++ (main.cpp)
     let cpp_itest2 = unsafe { cpp::create_itest2().unwrap() };
-    // Rust wrapper around ITest1 implemented in invoke.c
+    // ITest1 implemented in C (invoke.c)
     let c_itest1 = unsafe { c::create_itest1(0).unwrap() };
-    // ITest2 object tests ITest1 interface
     assert_eq!(cpp_itest2.entrypoint(Some(&c_itest1)), Ok(()));
+
+    // ITest3 (extends ITest1) implemented in C++ — verify version defaults to
+    // 1.0 when no method attributes are specified in the IDL
     let cpp_itest3 = unsafe { cpp::create_itest3().unwrap() };
     assert_eq!(cpp_itest3.single_in(0xdead), Ok(()));
-    {
-        // Test that an IDL with no method attributes defaults to 1.0
-        let expected = idlc_test::interfaces::itest1::IDLVersion::new(1,0,0);
-        let expected_val: u32 = expected.into();
-        assert_eq!(cpp_itest3.api_version(), Ok(expected_val));
-        assert_eq!(1, expected.major());
-        assert_eq!(0, expected.minor());
-        assert_eq!(0, expected.patch());
-    }
+    let expected = IDLVersion::new(1, 0, 0);
+    let expected_val: u32 = expected.into();
+    assert_eq!(cpp_itest3.api_version(), Ok(expected_val));
+    assert_eq!(1, expected.major());
+    assert_eq!(0, expected.minor());
+    assert_eq!(0, expected.patch());
 }
 
 #[test]
 fn to_cpp() {
-    // ITest2 Rust wrapper around C++ impl of ITest2 in main.cpp
+    // ITest2 implemented in C++ (main.cpp)
     let cpp_itest2 = unsafe { cpp::create_itest2().unwrap() };
+    // ITest1 implemented in C++ (main.cpp)
     let cpp_itest1 = unsafe { cpp::create_itest1(0).unwrap() };
     assert_eq!(cpp_itest2.entrypoint(Some(&cpp_itest1)), Ok(()));
 }
 
 #[test]
 fn to_rust() {
-    // ITest2 Rust wrapper around C++ impl of ITest2 in main.cpp
+    // ITest2 implemented in C++ (main.cpp)
     let cpp_itest2 = unsafe { cpp::create_itest2().unwrap() };
-    let rust_itest1: idlc_test::interfaces::itest1::ITest1 = implementation::ITest1::default().into();
+    // ITest1 implemented in Rust (implementation/test1.rs)
+    let rust_itest1: idlc_test::interfaces::itest1::ITest1 =
+        implementation::ITest1::default().into();
     assert_eq!(cpp_itest2.entrypoint(Some(&rust_itest1)), Ok(()));
-}
-
-#[test]
-fn implementation() {
-    // ITest2 Rust wrapper around C++ impl of ITest2 in main.cpp
-    let cpp_wrapper = unsafe { cpp::create_itest2().unwrap() };
-    // ITest1 Rust object, implemented in test1.rs
-    let input = implementation::ITest1::default().into();
-    // ITest2 object tests ITest1 interface
-    assert_eq!(cpp_wrapper.entrypoint(Some(&input)), Ok(()));
-    let cpp_wrapper_itest3 = unsafe { cpp::create_itest3().unwrap() };
-    assert_eq!(cpp_wrapper_itest3.single_in(0xdead), Ok(()));
-}
-
-#[test]
-fn invoke() {
-    let rust_wrapper: ITest2 = implementation::ITest2::new().into();
-    let input = unsafe { cpp::create_itest1(Default::default()).unwrap() };
-    assert_eq!(rust_wrapper.entrypoint(Some(&input)), Ok(()));
 }

--- a/tests/tests/cpp.rs
+++ b/tests/tests/cpp.rs
@@ -4,23 +4,71 @@
 #![cfg(not(miri))]
 
 use idlc_test::{
-    cpp::{create_itest1, create_itest2, create_itest3},
+    c, cpp,
     implementation,
     interfaces::itest2::ITest2,
 };
 
+// The Rust test harness requires that we directly interface with Rust object
+// only. However, underneath each of these, we can instantiate stub/proxy
+// objects from each of the supported languages.
+
+// The following tests all start from a C proxy and invoke to a different
+// server/skeleton backend. That way we ensure that we are covering all of the
+// possible combinations. Of course there is redundancy with other tests but
+// this way we get better code coverage.
+#[test]
+fn to_c() {
+    // ITest2 Rust wrapper around C++ impl of ITest2 in main.cpp
+    let cpp_itest2 = unsafe { cpp::create_itest2().unwrap() };
+    // Rust wrapper around ITest1 implemented in invoke.c
+    let c_itest1 = unsafe { c::create_itest1(0).unwrap() };
+    // ITest2 object tests ITest1 interface
+    assert_eq!(cpp_itest2.entrypoint(Some(&c_itest1)), Ok(()));
+    let cpp_itest3 = unsafe { cpp::create_itest3().unwrap() };
+    assert_eq!(cpp_itest3.single_in(0xdead), Ok(()));
+    {
+        // Test that an IDL with no method attributes defaults to 1.0
+        let expected = idlc_test::interfaces::itest1::IDLVersion::new(1,0,0);
+        let expected_val: u32 = expected.into();
+        assert_eq!(cpp_itest3.api_version(), Ok(expected_val));
+        assert_eq!(1, expected.major());
+        assert_eq!(0, expected.minor());
+        assert_eq!(0, expected.patch());
+    }
+}
+
+#[test]
+fn to_cpp() {
+    // ITest2 Rust wrapper around C++ impl of ITest2 in main.cpp
+    let cpp_itest2 = unsafe { cpp::create_itest2().unwrap() };
+    let cpp_itest1 = unsafe { cpp::create_itest1(0).unwrap() };
+    assert_eq!(cpp_itest2.entrypoint(Some(&cpp_itest1)), Ok(()));
+}
+
+#[test]
+fn to_rust() {
+    // ITest2 Rust wrapper around C++ impl of ITest2 in main.cpp
+    let cpp_itest2 = unsafe { cpp::create_itest2().unwrap() };
+    let rust_itest1: idlc_test::interfaces::itest1::ITest1 = implementation::ITest1::default().into();
+    assert_eq!(cpp_itest2.entrypoint(Some(&rust_itest1)), Ok(()));
+}
+
 #[test]
 fn implementation() {
-    let cpp_wrapper = unsafe { create_itest2().unwrap() };
+    // ITest2 Rust wrapper around C++ impl of ITest2 in main.cpp
+    let cpp_wrapper = unsafe { cpp::create_itest2().unwrap() };
+    // ITest1 Rust object, implemented in test1.rs
     let input = implementation::ITest1::default().into();
+    // ITest2 object tests ITest1 interface
     assert_eq!(cpp_wrapper.entrypoint(Some(&input)), Ok(()));
-    let cpp_wrapper_itest3 = unsafe { create_itest3().unwrap() };
+    let cpp_wrapper_itest3 = unsafe { cpp::create_itest3().unwrap() };
     assert_eq!(cpp_wrapper_itest3.single_in(0xdead), Ok(()));
 }
 
 #[test]
 fn invoke() {
     let rust_wrapper: ITest2 = implementation::ITest2::new().into();
-    let input = unsafe { create_itest1(Default::default()).unwrap() };
+    let input = unsafe { cpp::create_itest1(Default::default()).unwrap() };
     assert_eq!(rust_wrapper.entrypoint(Some(&input)), Ok(()));
 }

--- a/tests/tests/main.rs
+++ b/tests/tests/main.rs
@@ -1,8 +1,9 @@
 // Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
 // SPDX-License-Identifier: BSD-3-Clause
 
+#[cfg(not(miri))]
+use idlc_test::{c, cpp};
 use idlc_test::{
-    c, cpp,
     implementation::{self, ITest1},
     interfaces::itest2::ITest2,
 };
@@ -10,6 +11,7 @@ use idlc_test::{
 // The following tests start from a Rust ITest2 implementation (test2.rs) and
 // invoke every combination of ITest1 backend to verify cross-language FFI.
 
+#[cfg(not(miri))]
 #[test]
 fn to_c() {
     // ITest2 implemented in Rust (implementation/test2.rs)
@@ -31,6 +33,7 @@ fn to_c() {
     assert_eq!(0, expected.patch());
 }
 
+#[cfg(not(miri))]
 #[test]
 fn to_cpp() {
     // ITest2 implemented in Rust (implementation/test2.rs)

--- a/tests/tests/main.rs
+++ b/tests/tests/main.rs
@@ -2,9 +2,54 @@
 // SPDX-License-Identifier: BSD-3-Clause
 
 use idlc_test::{
+    c,
+    cpp,
     implementation::{self, ITest1},
     interfaces::itest2::ITest2,
 };
+
+// The Rust test harness requires that we directly interface with Rust object
+// only. However, underneath each of these, we can instantiate stub/proxy
+// objects from each of the supported languages.
+
+// The following tests all start from a C proxy and invoke to a different
+// server/skeleton backend. That way we ensure that we are covering all of the
+// possible combinations. Of course there is redundancy with other tests but
+// this way we get better code coverage.
+#[test]
+fn to_c() {
+    // ITest2 Rust object, implemented in test2.rs
+    let rust_itest2: ITest2 = implementation::ITest2::new().into();
+    // Rust wrapper around ITest1 implemented in invoke.c
+    let c_itest1 = unsafe { c::create_itest1(0).unwrap() };
+    // ITest2 object tests ITest1 interface
+    assert_eq!(rust_itest2.entrypoint(Some(&c_itest1)), Ok(()));
+    let rust_itest3: idlc_test::interfaces::itest3::ITest3 = implementation::ITest3::default().into();
+    assert_eq!(rust_itest3.single_in(0xdead), Ok(()));
+    {
+        // Test that an IDL with no method attributes defaults to 1.0
+        let expected = idlc_test::interfaces::itest1::IDLVersion::new(1,0,0);
+        let expected_val: u32 = expected.into();
+        assert_eq!(rust_itest3.api_version(), Ok(expected_val));
+        assert_eq!(1, expected.major());
+        assert_eq!(0, expected.minor());
+        assert_eq!(0, expected.patch());
+    }
+}
+
+#[test]
+fn to_cpp() {
+    let rust_itest2: ITest2 = implementation::ITest2::new().into();
+    let cpp_itest1 = unsafe { cpp::create_itest1(0).unwrap() };
+    assert_eq!(rust_itest2.entrypoint(Some(&cpp_itest1)), Ok(()));
+}
+
+#[test]
+fn to_rust() {
+    let rust_itest2: ITest2 = implementation::ITest2::new().into();
+    let rust_itest1 = ITest1::default().into();
+    assert_eq!(rust_itest2.entrypoint(Some(&rust_itest1)), Ok(()));
+}
 
 #[test]
 fn implementation_and_invoke() {

--- a/tests/tests/main.rs
+++ b/tests/tests/main.rs
@@ -2,51 +2,49 @@
 // SPDX-License-Identifier: BSD-3-Clause
 
 use idlc_test::{
-    c,
-    cpp,
+    c, cpp,
     implementation::{self, ITest1},
     interfaces::itest2::ITest2,
 };
 
-// The Rust test harness requires that we directly interface with Rust object
-// only. However, underneath each of these, we can instantiate stub/proxy
-// objects from each of the supported languages.
+// The following tests start from a Rust ITest2 implementation (test2.rs) and
+// invoke every combination of ITest1 backend to verify cross-language FFI.
 
-// The following tests all start from a C proxy and invoke to a different
-// server/skeleton backend. That way we ensure that we are covering all of the
-// possible combinations. Of course there is redundancy with other tests but
-// this way we get better code coverage.
 #[test]
 fn to_c() {
-    // ITest2 Rust object, implemented in test2.rs
+    // ITest2 implemented in Rust (implementation/test2.rs)
     let rust_itest2: ITest2 = implementation::ITest2::new().into();
-    // Rust wrapper around ITest1 implemented in invoke.c
+    // ITest1 implemented in C (invoke.c)
     let c_itest1 = unsafe { c::create_itest1(0).unwrap() };
-    // ITest2 object tests ITest1 interface
     assert_eq!(rust_itest2.entrypoint(Some(&c_itest1)), Ok(()));
-    let rust_itest3: idlc_test::interfaces::itest3::ITest3 = implementation::ITest3::default().into();
+
+    // ITest3 (extends ITest1) implemented in Rust — verify version defaults to
+    // 1.0 when no method attributes are specified in the IDL
+    let rust_itest3: idlc_test::interfaces::itest3::ITest3 =
+        implementation::ITest3::default().into();
     assert_eq!(rust_itest3.single_in(0xdead), Ok(()));
-    {
-        // Test that an IDL with no method attributes defaults to 1.0
-        let expected = idlc_test::interfaces::itest1::IDLVersion::new(1,0,0);
-        let expected_val: u32 = expected.into();
-        assert_eq!(rust_itest3.api_version(), Ok(expected_val));
-        assert_eq!(1, expected.major());
-        assert_eq!(0, expected.minor());
-        assert_eq!(0, expected.patch());
-    }
+    let expected = idlc_test::interfaces::itest1::IDLVersion::new(1, 0, 0);
+    let expected_val: u32 = expected.into();
+    assert_eq!(rust_itest3.api_version(), Ok(expected_val));
+    assert_eq!(1, expected.major());
+    assert_eq!(0, expected.minor());
+    assert_eq!(0, expected.patch());
 }
 
 #[test]
 fn to_cpp() {
+    // ITest2 implemented in Rust (implementation/test2.rs)
     let rust_itest2: ITest2 = implementation::ITest2::new().into();
+    // ITest1 implemented in C++ (main.cpp)
     let cpp_itest1 = unsafe { cpp::create_itest1(0).unwrap() };
     assert_eq!(rust_itest2.entrypoint(Some(&cpp_itest1)), Ok(()));
 }
 
 #[test]
 fn to_rust() {
+    // ITest2 implemented in Rust (implementation/test2.rs)
     let rust_itest2: ITest2 = implementation::ITest2::new().into();
+    // ITest1 implemented in Rust (implementation/test1.rs)
     let rust_itest1 = ITest1::default().into();
     assert_eq!(rust_itest2.entrypoint(Some(&rust_itest1)), Ok(()));
 }


### PR DESCRIPTION
Fix holes in test coverage and add documentation to explain how the test framework covers the exercises the autogenerated code.