### PR TITLE
Prefix reserved words

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -331,6 +331,7 @@ name = "idlc_codegen_c"
 version = "0.3.0"
 dependencies = [
  "idlc_codegen",
+ "idlc_errors",
  "idlc_mir",
 ]
 
@@ -340,6 +341,7 @@ version = "0.3.0"
 dependencies = [
  "idlc_codegen",
  "idlc_codegen_c",
+ "idlc_errors",
  "idlc_mir",
 ]
 
@@ -349,6 +351,7 @@ version = "0.3.0"
 dependencies = [
  "convert_case",
  "idlc_codegen",
+ "idlc_errors",
  "idlc_mir",
 ]
 

--- a/idlc_codegen/src/keywords.rs
+++ b/idlc_codegen/src/keywords.rs
@@ -1,15 +1,15 @@
 // Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
 // SPDX-License-Identifier: BSD-3-Clause
 
-/// Reserved keywords for each supported output language.
-///
-/// C17: [https://www.open-std.org/JTC1/SC22/WG14/www/docs/n2310.pdf](https://www.open-std.org/JTC1/SC22/WG14/www/docs/n2310.pdf)
-/// C++23: [https://www.open-std.org/JTC1/SC22/WG21/docs/papers/2023/n4950.pdf](https://docs.oracle.com/javase/specs/jls/se22/html/jls-3.html#jls-3.9)
-/// Java: [https://docs.oracle.com/javase/specs/jls/se22/html/jls-3.html#jls-3.9](https://docs.oracle.com/javase/specs/jls/se22/html/jls-3.html#jls-3.9)
-///
-/// Rust keywords are not added here since the language provides a way to escape
-/// keywords using the `r#` syntax. See
-/// [raw-identifiers](https://doc.rust-lang.org/rust-by-example/compatibility/raw_identifiers.html#raw-identifiers)
+//! Reserved keywords for each supported output language.
+//!
+//! C17: [https://www.open-std.org/JTC1/SC22/WG14/www/docs/n2310.pdf](https://www.open-std.org/JTC1/SC22/WG14/www/docs/n2310.pdf)
+//! C++23: [https://www.open-std.org/JTC1/SC22/WG21/docs/papers/2023/n4950.pdf](https://docs.oracle.com/javase/specs/jls/se22/html/jls-3.html#jls-3.9)
+//! Java: [https://docs.oracle.com/javase/specs/jls/se22/html/jls-3.html#jls-3.9](https://docs.oracle.com/javase/specs/jls/se22/html/jls-3.html#jls-3.9)
+//!
+//! Rust keywords are not added here since the language provides a way to escape
+//! keywords using the `r#` syntax. See
+//! [raw-identifiers](https://doc.rust-lang.org/rust-by-example/compatibility/raw_identifiers.html#raw-identifiers)
 
 /// C17 reserved keywords.
 pub const C_KEYWORDS: &[&str] = &[

--- a/idlc_codegen/src/keywords.rs
+++ b/idlc_codegen/src/keywords.rs
@@ -1,68 +1,221 @@
 // Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
 // SPDX-License-Identifier: BSD-3-Clause
 
-pub mod invoke {
-    // Name of function which gets added to all auto-generated outputs
-    pub const VERSION_FUNC_NAME: &str = "api_version";
-}
-
-macro_rules! keyword_gen {
-    ($($lang: literal: [$($value: expr),*]),*) => {
-        &[$($($value,)*)*]
-    };
-}
-
-/// This crate has to ensure that all codegenerations succeed, so a keyword that isn't reserved in
-/// Rust might be reserved in a different target language. This summarizes all the codegen backends
-/// we support.
+/// Reserved keywords for each supported output language.
 ///
 /// C17: [https://www.open-std.org/JTC1/SC22/WG14/www/docs/n2310.pdf](https://www.open-std.org/JTC1/SC22/WG14/www/docs/n2310.pdf)
 /// C++23: [https://www.open-std.org/JTC1/SC22/WG21/docs/papers/2023/n4950.pdf](https://docs.oracle.com/javase/specs/jls/se22/html/jls-3.html#jls-3.9)
-/// Java: [https://docs.oracle.com/javase/specs/jls/se22/html/jls-3.html#jls-3.9](https://docs.oracle.com/javase/specs/jls/se22/html/jls-3.html#jls-3.9)/
-///
-/// # Footnotes
+/// Java: [https://docs.oracle.com/javase/specs/jls/se22/html/jls-3.html#jls-3.9](https://docs.oracle.com/javase/specs/jls/se22/html/jls-3.html#jls-3.9)
 ///
 /// Rust keywords are not added here since the language provides a way to escape
 /// keywords using the `r#` syntax. See
 /// [raw-identifiers](https://doc.rust-lang.org/rust-by-example/compatibility/raw_identifiers.html#raw-identifiers)
-const RESERVED_KEYWORDS: &[&str] = keyword_gen! {
-    "Mink IDL": [invoke::VERSION_FUNC_NAME],
-    "C17": [
-        "auto", "break", "case", "char", "const", "continue", "default", "do", "double",
-        "else", "enum", "extern", "float", "for", "goto", "if", "inline", "int",
-        "long", "register", "restrict", "return", "short", "signed", "sizeof", "static",
-        "struct", "switch", "typedef", "union", "unsigned", "void", "volatile",
-        "while", "_Alignas", "_Alignof", "_Atomic", "_Bool", "_Complex", "_Generic",
-        "_Imaginary", "_Noreturn", "_Static_assert", "_Thread_local"
-    ],
-    "C++-23": [
-        "alignas", "alignof", "asm", "auto", "bool", "break", "case", "catch",
-        "char", "char8_t", "char16_t", "char32_t", "class", "concept", "const",
-        "consteval", "constexpr", "constinit", "const_cast", "continue", "co_await",
-        "co_return", "co_yield", "decltype", "default", "delete", "do", "double",
-        "dynamic_cast", "else", "enum", "explicit", "export", "extern", "false",
-        "float", "for", "friend", "goto", "if", "inline", "int", "long", "mutable",
-        "namespace", "new", "noexcept", "nullptr", "operator", "private",
-        "protected", "public", "register", "reinterpret_cast", "requires", "return",
-        "short", "signed", "sizeof", "static", "static_assert", "static_cast",
-        "struct", "switch", "template", "this", "thread_local", "throw", "true",
-        "try", "typedef", "typeid", "typename", "union", "unsigned", "using",
-        "virtual", "void", "volatile", "wchar_t", "while"
-    ],
-    "Java": [
-        "abstract", "continue", "for", "new", "switch", "assert", "default", "if",
-        "package", "synchronized", "boolean", "do", "goto", "private", "this", "break",
-        "double", "implements", "protected", "throw", "byte", "else", "import",
-        "public", "throws", "case", "enum", "instanceof", "return", "transient",
-        "catch", "extends", "int", "short", "try", "char", "final", "interface",
-        "static", "void", "class", "finally", "long", "strictfp", "volatile", "const",
-        "float", "native", "super", "while"
-    ]
-};
 
-/// Checks if the given input is a reserved keyword supported by any of the backend languages.
+/// C17 reserved keywords.
+pub const C_KEYWORDS: &[&str] = &[
+    "auto",
+    "break",
+    "case",
+    "char",
+    "const",
+    "continue",
+    "default",
+    "do",
+    "double",
+    "else",
+    "enum",
+    "extern",
+    "float",
+    "for",
+    "goto",
+    "if",
+    "inline",
+    "int",
+    "long",
+    "register",
+    "restrict",
+    "return",
+    "short",
+    "signed",
+    "sizeof",
+    "static",
+    "struct",
+    "switch",
+    "typedef",
+    "union",
+    "unsigned",
+    "void",
+    "volatile",
+    "while",
+    "_Alignas",
+    "_Alignof",
+    "_Atomic",
+    "_Bool",
+    "_Complex",
+    "_Generic",
+    "_Imaginary",
+    "_Noreturn",
+    "_Static_assert",
+    "_Thread_local",
+];
+
+/// C++23 reserved keywords.
+pub const CPP_KEYWORDS: &[&str] = &[
+    "alignas",
+    "alignof",
+    "asm",
+    "auto",
+    "bool",
+    "break",
+    "case",
+    "catch",
+    "char",
+    "char8_t",
+    "char16_t",
+    "char32_t",
+    "class",
+    "concept",
+    "const",
+    "consteval",
+    "constexpr",
+    "constinit",
+    "const_cast",
+    "continue",
+    "co_await",
+    "co_return",
+    "co_yield",
+    "decltype",
+    "default",
+    "delete",
+    "do",
+    "double",
+    "dynamic_cast",
+    "else",
+    "enum",
+    "explicit",
+    "export",
+    "extern",
+    "false",
+    "float",
+    "for",
+    "friend",
+    "goto",
+    "if",
+    "inline",
+    "int",
+    "long",
+    "mutable",
+    "namespace",
+    "new",
+    "noexcept",
+    "nullptr",
+    "operator",
+    "private",
+    "protected",
+    "public",
+    "register",
+    "reinterpret_cast",
+    "requires",
+    "return",
+    "short",
+    "signed",
+    "sizeof",
+    "static",
+    "static_assert",
+    "static_cast",
+    "struct",
+    "switch",
+    "template",
+    "this",
+    "thread_local",
+    "throw",
+    "true",
+    "try",
+    "typedef",
+    "typeid",
+    "typename",
+    "union",
+    "unsigned",
+    "using",
+    "virtual",
+    "void",
+    "volatile",
+    "wchar_t",
+    "while",
+];
+
+/// Java reserved keywords (keywords + reserved literals per JLS §3.9).
+pub const JAVA_KEYWORDS: &[&str] = &[
+    "abstract",
+    "continue",
+    "for",
+    "new",
+    "switch",
+    "assert",
+    "default",
+    "if",
+    "package",
+    "synchronized",
+    "boolean",
+    "do",
+    "goto",
+    "private",
+    "this",
+    "break",
+    "double",
+    "implements",
+    "protected",
+    "throw",
+    "byte",
+    "else",
+    "import",
+    "public",
+    "throws",
+    "case",
+    "enum",
+    "instanceof",
+    "return",
+    "transient",
+    "catch",
+    "extends",
+    "int",
+    "short",
+    "try",
+    "char",
+    "final",
+    "interface",
+    "static",
+    "void",
+    "class",
+    "finally",
+    "long",
+    "strictfp",
+    "volatile",
+    "const",
+    "float",
+    "native",
+    "super",
+    "while",
+];
+
+/// Returns `true` when `input` is a C17 reserved keyword.
+pub fn is_reserved_for_c(input: &str) -> bool {
+    C_KEYWORDS.contains(&input)
+}
+
+/// Returns `true` when `input` is a C++23 reserved keyword.
+pub fn is_reserved_for_cpp(input: &str) -> bool {
+    CPP_KEYWORDS.contains(&input)
+}
+
+/// Returns `true` when `input` is a Java reserved keyword.
+pub fn is_reserved_for_java(input: &str) -> bool {
+    JAVA_KEYWORDS.contains(&input)
+}
+
+/// Checks if the given input is a reserved keyword in any of the supported backend languages.
 pub fn is_reserved_keyword(input: &str) -> bool {
-    RESERVED_KEYWORDS.contains(&input)
+    is_reserved_for_c(input) || is_reserved_for_cpp(input) || is_reserved_for_java(input)
 }
 
 #[cfg(test)]
@@ -70,9 +223,33 @@ mod tests {
     use super::*;
 
     #[test]
-    fn is_reserved() {
-        for keyword in RESERVED_KEYWORDS {
-            assert!(is_reserved_keyword(keyword));
+    fn c_keywords_reserved() {
+        for kw in C_KEYWORDS {
+            assert!(is_reserved_for_c(kw), "{kw} not detected as C keyword");
+        }
+    }
+
+    #[test]
+    fn cpp_keywords_reserved() {
+        for kw in CPP_KEYWORDS {
+            assert!(is_reserved_for_cpp(kw), "{kw} not detected as C++ keyword");
+        }
+    }
+
+    #[test]
+    fn java_keywords_reserved() {
+        for kw in JAVA_KEYWORDS {
+            assert!(
+                is_reserved_for_java(kw),
+                "{kw} not detected as Java keyword"
+            );
+        }
+    }
+
+    #[test]
+    fn is_reserved_union() {
+        for kw in C_KEYWORDS.iter().chain(CPP_KEYWORDS).chain(JAVA_KEYWORDS) {
+            assert!(is_reserved_keyword(kw), "{kw} not in union");
         }
     }
 }

--- a/idlc_codegen/src/lib.rs
+++ b/idlc_codegen/src/lib.rs
@@ -7,8 +7,6 @@ pub mod functions;
 pub mod marking;
 pub mod serialization;
 
-// TODO: Remove this when we indeed start banning idents matching reserved keywords
-#[allow(dead_code)]
 pub mod keywords;
 
 use std::path::PathBuf;

--- a/idlc_codegen_c/Cargo.toml
+++ b/idlc_codegen_c/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2021"
 
 [dependencies]
 idlc_codegen = { path="../idlc_codegen" }
+idlc_errors = { path="../idlc_errors" }
 idlc_mir = { path="../idlc_mir" }
 
 [package.metadata.workspaces]

--- a/idlc_codegen_c/src/globals.rs
+++ b/idlc_codegen_c/src/globals.rs
@@ -16,7 +16,7 @@ pub fn emit_struct(r#struct: &StructInner) -> String {
     result.push_str("typedef struct {\n");
 
     for field in &r#struct.fields {
-        let ident = &field.ident;
+        let ident = crate::safe_ident_c(field.ident.as_ref());
         let count = field.val.1.get();
         let ty = match &field.val.0 {
             &idlc_mir::Type::Primitive(primitive) => change_primitive(primitive).to_string(),
@@ -30,7 +30,8 @@ pub fn emit_struct(r#struct: &StructInner) -> String {
             format!("{INDENT}{ty} {ident}[{count}];\n")
         });
     }
-    result.push_str(&format!("}} {};\n\n", r#struct.ident));
+    let struct_ident = crate::safe_ident_c(r#struct.ident.as_ref());
+    result.push_str(&format!("}} {struct_ident};\n\n"));
     result
 }
 

--- a/idlc_codegen_c/src/interface/functions/implementation.rs
+++ b/idlc_codegen_c/src/interface/functions/implementation.rs
@@ -291,6 +291,7 @@ pub fn emit(
     documentation: &str,
     counts: &idlc_codegen::counts::Counter,
     signature: &super::signature::Signature,
+    fn_ident: &str,
 ) -> String {
     let ident = &function.ident;
     let total = counts.total();
@@ -329,7 +330,7 @@ pub fn emit(
     format!(
         r#"
 {documentation}
-static inline int32_t {current_iface_ident}_{ident}(Object self{params})
+static inline int32_t {current_iface_ident}_{fn_ident}(Object self{params})
 {{
 {formatted_body}
 }}

--- a/idlc_codegen_c/src/interface/mod.rs
+++ b/idlc_codegen_c/src/interface/mod.rs
@@ -1,8 +1,7 @@
 // Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
 // SPDX-License-Identifier: BSD-3-Clause
 
-use idlc_codegen::keywords::invoke::VERSION_FUNC_NAME;
-use idlc_mir::{APIVersion, Interface, InterfaceNode};
+use idlc_mir::{APIVersion, Interface, InterfaceNode, VERSION_FUNC_NAME};
 
 pub mod functions;
 pub mod variable_names;
@@ -42,6 +41,7 @@ pub fn emit_interface_impl(interface: &Interface, is_no_typed_objects: bool) -> 
                 f,
                 idlc_codegen::documentation::DocumentationStyle::C,
             );
+            let fn_ident = crate::safe_ident_c(f.ident.as_ref());
             if is_root {
                 op_codes.push_str(&format!("#define {}_OP_{} {}\n", ident, f.ident, f.id));
             }
@@ -52,6 +52,7 @@ pub fn emit_interface_impl(interface: &Interface, is_no_typed_objects: bool) -> 
                 &documentation,
                 &counts,
                 &signature,
+                &fn_ident,
             ));
         }
     };

--- a/idlc_codegen_c/src/lib.rs
+++ b/idlc_codegen_c/src/lib.rs
@@ -7,3 +7,14 @@ pub mod interface;
 pub mod types;
 
 pub use generator::Generator;
+
+pub(crate) fn safe_ident_c(ident: &str) -> std::borrow::Cow<'_, str> {
+    if idlc_codegen::keywords::is_reserved_for_c(ident) {
+        idlc_errors::warn!(
+            "Identifier `{ident}` is a reserved C keyword; renamed to `_{ident}` to avoid compilation issues"
+        );
+        std::borrow::Cow::Owned(format!("_{ident}"))
+    } else {
+        std::borrow::Cow::Borrowed(ident)
+    }
+}

--- a/idlc_codegen_cpp/Cargo.toml
+++ b/idlc_codegen_cpp/Cargo.toml
@@ -8,6 +8,7 @@ edition = "2021"
 [dependencies]
 idlc_codegen_c = { path="../idlc_codegen_c" }
 idlc_codegen = { path="../idlc_codegen" }
+idlc_errors = { path="../idlc_errors" }
 idlc_mir = { path="../idlc_mir" }
 
 [package.metadata.workspaces]

--- a/idlc_codegen_cpp/src/interface/functions/implementation.rs
+++ b/idlc_codegen_cpp/src/interface/functions/implementation.rs
@@ -232,6 +232,7 @@ pub fn emit(
     documentation: &str,
     counts: &idlc_codegen::counts::Counter,
     signature: &super::signature::Signature,
+    fn_ident: &str,
 ) -> String {
     let ident = &function.ident;
     let total = counts.total();
@@ -271,7 +272,7 @@ pub fn emit(
     format!(
         r#"
 {documentation}
-{INDENT}virtual int32_t {ident}({params}) {{
+{INDENT}virtual int32_t {fn_ident}({params}) {{
 {formatted_body}
 {INDENT}}}
 "#

--- a/idlc_codegen_cpp/src/interface/functions/invoke.rs
+++ b/idlc_codegen_cpp/src/interface/functions/invoke.rs
@@ -176,12 +176,13 @@ pub fn emit(
     function: &idlc_mir::Function,
     signature: &super::signature::Signature,
     counts: &idlc_codegen::counts::Counter,
+    fn_ident: &str,
 ) -> String {
     let ident = &function.ident;
     let invoke = Invoke::new(function);
     let return_idents = signature.return_idents();
 
-    let call = format!("int32_t r = {ident}({return_idents});");
+    let call = format!("int32_t r = {fn_ident}({return_idents});");
 
     let counts = format!(
         "{0}, {1}, {2}, {3}",

--- a/idlc_codegen_cpp/src/interface/mod.rs
+++ b/idlc_codegen_cpp/src/interface/mod.rs
@@ -1,8 +1,7 @@
 // Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
 // SPDX-License-Identifier: BSD-3-Clause
 
-use idlc_codegen::keywords::invoke::VERSION_FUNC_NAME;
-use idlc_mir::{APIVersion, Interface, InterfaceNode};
+use idlc_mir::{APIVersion, Interface, InterfaceNode, VERSION_FUNC_NAME};
 
 mod functions;
 
@@ -45,12 +44,13 @@ pub fn emit_interface_impl(interface: &Interface) -> String {
                 f,
                 idlc_codegen::documentation::DocumentationStyle::C,
             );
+            let fn_ident = crate::safe_ident_cpp(f.ident.as_ref());
             if is_root {
                 let params = signature.params();
                 func_titles.push_str(&format!(
                     r#"
     virtual int32_t {}({}) = 0;"#,
-                    f.ident, params,
+                    fn_ident, params,
                 ));
                 op_codes.push_str(&format!(
                     r#"
@@ -63,6 +63,7 @@ pub fn emit_interface_impl(interface: &Interface) -> String {
                 &documentation,
                 &counts,
                 &signature,
+                &fn_ident,
             ));
         }
     };
@@ -142,20 +143,22 @@ pub fn emit_interface_invoke(interface: &Interface) -> String {
     interface.iter().skip(1).for_each(|iface| {
         iface.nodes.iter().for_each(|node| {
             if let InterfaceNode::Function(f) = node {
+                let fn_ident = crate::safe_ident_cpp(f.ident.as_ref());
                 let counts = idlc_codegen::counts::Counter::new(f);
                 let signature = functions::signature::Signature::new(f, &counts);
 
-                invokes.push_str(&functions::invoke::emit(f, &signature, &counts));
+                invokes.push_str(&functions::invoke::emit(f, &signature, &counts, &fn_ident));
             }
         })
     });
 
     for node in &interface.nodes {
         if let InterfaceNode::Function(f) = node {
+            let fn_ident = crate::safe_ident_cpp(f.ident.as_ref());
             let counts = idlc_codegen::counts::Counter::new(f);
             let signature = functions::signature::Signature::new(f, &counts);
 
-            invokes.push_str(&functions::invoke::emit(f, &signature, &counts));
+            invokes.push_str(&functions::invoke::emit(f, &signature, &counts, &fn_ident));
         }
     }
 

--- a/idlc_codegen_cpp/src/lib.rs
+++ b/idlc_codegen_cpp/src/lib.rs
@@ -5,3 +5,14 @@ mod generator;
 pub mod interface;
 
 pub use generator::Generator;
+
+pub(crate) fn safe_ident_cpp(ident: &str) -> std::borrow::Cow<'_, str> {
+    if idlc_codegen::keywords::is_reserved_for_cpp(ident) {
+        idlc_errors::warn!(
+            "Identifier `{ident}` is a reserved C++ keyword; renamed to `_{ident}` to avoid compilation issues"
+        );
+        std::borrow::Cow::Owned(format!("_{ident}"))
+    } else {
+        std::borrow::Cow::Borrowed(ident)
+    }
+}

--- a/idlc_codegen_java/Cargo.toml
+++ b/idlc_codegen_java/Cargo.toml
@@ -8,6 +8,7 @@ edition = "2021"
 [dependencies]
 convert_case = "0.6.0"
 idlc_codegen = { path="../idlc_codegen" }
+idlc_errors = { path="../idlc_errors" }
 idlc_mir = { path="../idlc_mir" }
 
 [package.metadata.workspaces]

--- a/idlc_codegen_java/src/globals.rs
+++ b/idlc_codegen_java/src/globals.rs
@@ -7,10 +7,10 @@ use crate::types::change_primitive;
 
 pub fn emit_struct(r#struct: &StructInner) -> String {
     let mut contents = String::new();
-    let struct_ident = &r#struct.ident;
+    let struct_ident = crate::safe_ident_java(r#struct.ident.as_ref());
 
     for field in &r#struct.fields {
-        let ident = &field.ident;
+        let ident = crate::safe_ident_java(field.ident.as_ref());
         let count = field.val.1.get();
         let ty = match &field.val.0 {
             &idlc_mir::Type::Primitive(primitive) => change_primitive(primitive).to_string(),

--- a/idlc_codegen_java/src/interface/functions/implementation.rs
+++ b/idlc_codegen_java/src/interface/functions/implementation.rs
@@ -423,6 +423,7 @@ pub fn emit(
     documentation: &str,
     counts: &idlc_codegen::counts::Counter,
     signature: &super::signature::Signature,
+    fn_ident: &str,
 ) -> String {
     let ident = &function.ident;
 
@@ -487,7 +488,7 @@ pub fn emit(
         r#"
         {documentation}
         @Override
-        public void {ident}({params}) throws IMinkObject.InvokeException {{
+        public void {fn_ident}({params}) throws IMinkObject.InvokeException {{
             {inputs}
             {initializations}
             minkObject.invoke({iface_ident}_{OP_ID}_{ident}, {bi}, {bo_sizes}, {bo}, {oi}, {oo});

--- a/idlc_codegen_java/src/interface/functions/traits.rs
+++ b/idlc_codegen_java/src/interface/functions/traits.rs
@@ -2,15 +2,14 @@
 // SPDX-License-Identifier: BSD-3-Clause
 
 pub fn emit(
-    function: &idlc_mir::Function,
     documentation: &str,
     signature: &super::signature::Signature,
+    fn_ident: &str,
 ) -> String {
-    let ident = &function.ident;
     let params = super::signature::iter_to_string(signature.params());
     format!(
         r#"{documentation}
-    void {ident}({params}) throws IMinkObject.InvokeException;
+    void {fn_ident}({params}) throws IMinkObject.InvokeException;
     "#
     )
 }

--- a/idlc_codegen_java/src/interface/mod.rs
+++ b/idlc_codegen_java/src/interface/mod.rs
@@ -39,10 +39,10 @@ pub fn emit_interface(interface: &Interface, input_name: &str) -> String {
                 ))
             }
             InterfaceNode::Function(f) => {
-                let fn_ident = &f.ident;
+                let raw_fn_ident = f.ident.as_ref();
                 let id = f.id;
                 op_codes.push_str(&format!(
-                    r#"int {ident}_{OP_ID}_{fn_ident} = {id};
+                    r#"int {ident}_{OP_ID}_{raw_fn_ident} = {id};
     "#
                 ));
                 let counts = idlc_codegen::counts::Counter::new(f);
@@ -51,6 +51,7 @@ pub fn emit_interface(interface: &Interface, input_name: &str) -> String {
                     f,
                     idlc_codegen::documentation::DocumentationStyle::Java,
                 );
+                let fn_ident = crate::safe_ident_java(raw_fn_ident);
 
                 implementations.push_str(&functions::implementation::emit(
                     f,
@@ -58,9 +59,14 @@ pub fn emit_interface(interface: &Interface, input_name: &str) -> String {
                     &documentation,
                     &counts,
                     &signature,
+                    &fn_ident,
                 ));
                 invokes.push_str(&functions::invoke::emit(f, ident, &iface.ident, &signature));
-                traits.push_str(&functions::traits::emit(f, &documentation, &signature));
+                traits.push_str(&functions::traits::emit(
+                    &documentation,
+                    &signature,
+                    &fn_ident,
+                ));
             }
         });
     });

--- a/idlc_codegen_java/src/lib.rs
+++ b/idlc_codegen_java/src/lib.rs
@@ -7,3 +7,14 @@ mod interface;
 mod types;
 
 pub use generator::Generator;
+
+pub(crate) fn safe_ident_java(ident: &str) -> std::borrow::Cow<'_, str> {
+    if idlc_codegen::keywords::is_reserved_for_java(ident) {
+        idlc_errors::warn!(
+            "Identifier `{ident}` is a reserved Java keyword; renamed to `_{ident}` to avoid compilation issues"
+        );
+        std::borrow::Cow::Owned(format!("_{ident}"))
+    } else {
+        std::borrow::Cow::Borrowed(ident)
+    }
+}

--- a/idlc_codegen_rust/src/globals.rs
+++ b/idlc_codegen_rust/src/globals.rs
@@ -34,16 +34,16 @@ pub fn emit_struct(r#struct: &StructInner) -> String {
         };
 
         inner.push_str(&if count == 1 {
-            format!("pub {ident}: {ty},\n")
+            format!("pub r#{ident}: {ty},\n")
         } else {
-            format!("pub {ident}: [{ty}; {count}],\n")
+            format!("pub r#{ident}: [{ty}; {count}],\n")
         });
     }
     format!(
         r#"
 #[repr(C)]
 #[derive({derives})]
-pub struct {ident} {{
+pub struct r#{ident} {{
     {inner}
 }}
 "#,

--- a/idlc_codegen_rust/src/interface/mod.rs
+++ b/idlc_codegen_rust/src/interface/mod.rs
@@ -3,8 +3,7 @@
 
 use crate::globals::emit_const;
 
-use idlc_codegen::keywords::invoke::VERSION_FUNC_NAME;
-use idlc_mir::{APIVersion, Interface, InterfaceNode};
+use idlc_mir::{APIVersion, Interface, InterfaceNode, VERSION_FUNC_NAME};
 
 mod error;
 mod functions;

--- a/idlc_mir/src/lib.rs
+++ b/idlc_mir/src/lib.rs
@@ -1,6 +1,9 @@
 // Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
 // SPDX-License-Identifier: BSD-3-Clause
 
+// Name of function which gets added to all auto-generated outputs
+pub const VERSION_FUNC_NAME: &str = "api_version";
+
 pub mod mir;
 pub mod named_version;
 

--- a/idlc_mir_passes/src/interface_verifier.rs
+++ b/idlc_mir_passes/src/interface_verifier.rs
@@ -5,7 +5,7 @@ use std::collections::HashSet;
 
 use crate::MirCompilerPass;
 
-use idlc_mir::{InterfaceNode, Node, ParamTypeIn, ParamTypeOut, Struct, Type};
+use idlc_mir::{InterfaceNode, Node, ParamTypeIn, ParamTypeOut, Struct, Type, VERSION_FUNC_NAME};
 
 pub struct InterfaceVerifier<'mir> {
     mir: &'mir idlc_mir::Mir,
@@ -39,6 +39,14 @@ impl MirCompilerPass<'_> for InterfaceVerifier<'_> {
                         InterfaceNode::Error(e) => consts.add_ident(&e.ident, from),
                         InterfaceNode::Function(f) => {
                             functions.add_ident(&f.ident, from);
+
+                            if VERSION_FUNC_NAME == f.ident.as_ref() {
+                                idlc_errors::unrecoverable!(
+                                    "Method `{}::{}` conflicts with Mink IDL reserved word",
+                                    src.ident,
+                                    f.ident
+                                );
+                            }
 
                             let mut args_array_in = false;
                             let mut args_value_in = false;

--- a/idlc_mir_passes/tests/interface_verifier.rs
+++ b/idlc_mir_passes/tests/interface_verifier.rs
@@ -147,3 +147,14 @@ fn obj_with_obj_array_output() {
         ",
     );
 }
+
+#[should_panic = "conflicts with Mink IDL reserved word"]
+#[test]
+fn method_named_api_version() {
+    verify(
+        r"
+        interface IFoo {
+            method api_version();
+        };",
+    );
+}

--- a/tests/c/invoke.c
+++ b/tests/c/invoke.c
@@ -300,6 +300,10 @@ int32_t itest1_objects_in_struct(struct CTest1 *ctx, const ObjInStruct *input,
   return Object_OK;
 }
 
+int32_t itest1_delete(struct CTest1 *ctx, double key_val) {
+  return Object_OK;
+}
+
 int32_t itest1_derive_v0(struct CTest1 *ctx, uint32_t a_val) {
   return Object_OK;
 }
@@ -520,6 +524,10 @@ int32_t itest3_test_obj_array_out(struct CTest1 *ctx, Object (*o_ptr)[3],
 int32_t itest3_objects_in_struct(struct CTest1 *ctx, const ObjInStruct *input,
                                  ObjInStruct *output) {
   return itest1_objects_in_struct(ctx, input, output);
+}
+
+int32_t itest3_delete(struct CTest1 *ctx, double key_val) {
+  return Object_OK;
 }
 
 int32_t itest3_derive_v0(struct CTest1 *ctx, uint32_t a_val) {

--- a/tests/cpp/main.cpp
+++ b/tests/cpp/main.cpp
@@ -162,6 +162,9 @@ public:
     return Object_OK;
   }
 
+  int32_t _delete(double key_val) {
+    return Object_OK;
+  }
   int32_t derive_v0(uint32_t a_val) {
     return Object_OK;
   }
@@ -487,6 +490,9 @@ public:
     output_ref.first_obj = create_cpp_itest1(1);
     output_ref.second_obj = create_cpp_itest1(2);
     output_ref.should_be_empty = Object_NULL;
+    return Object_OK;
+  }
+  int32_t _delete(double key_val) {
     return Object_OK;
   }
   int32_t derive_v0(uint32_t a_val) {

--- a/tests/idl/ITest.idl
+++ b/tests/idl/ITest.idl
@@ -7,8 +7,9 @@ struct ObjInStruct {
   ITest1 second_obj;
 };
 
-struct F1 {
-    uint32 a;
+// The purpose of this struct is to show reserved words are handled properly
+struct break {
+    uint32 switch;
 };
 
 struct SingleEncapsulated {

--- a/tests/idl/ITest.idl
+++ b/tests/idl/ITest.idl
@@ -65,6 +65,7 @@ interface ITest1 {
   method test_obj_array_out(out ITest1[3] out, out uint32 a);
   method objects_in_struct(in ObjInStruct input, out ObjInStruct output);
   method no_args();
+  method delete(in float64 key); // To show that reserved words are handled properly
 
   #[version = 1.0]
   method derive_v0(in uint32 a); // the default version attribute should have no effect. Cannot have major version less than 1.

--- a/tests/src/implementation/test1.rs
+++ b/tests/src/implementation/test1.rs
@@ -239,6 +239,10 @@ macro_rules! itest1_impl {
             }
 
             #[allow(unused_variables)]
+            fn r#delete(&mut self, r#key: f64) -> Result<(), itest1::Error> {
+                Ok(())
+            }
+            #[allow(unused_variables)]
             fn r#derive_v0(&mut self, r#input: u32) -> Result<(), itest1::Error> {
                 Ok(())
             }


### PR DESCRIPTION
To match the behavior of the legacy IDL compiler, adopt the following behavior:
1. Issue a warning when a method name matches a reserved word of the output language
2. Prefix the method name with `_` during code generation.

The warning issued by the legacy compiler is: `Warning: Method name appended due to reserved keywords conflict`.
The legacy compiler has a list of words for Java and C++ but it is not clear where the list came from. These are used for method names. There is also a list for C reserved words - also of unknown origin - that applies only to `struct` definitions.

---

This change adopts the legacy behavior and enhances it in a few ways:
1. Increase the set of words for C, C++, and Java as well as document the origin of the word sets.
2. Rename structs _and struct fields_ for C code generation, which is also susceptible to C compilation errors.

In addition to the above changes, throw an error when the method name is `api_version`. This is the 1st Mink reserved word and it will be introduced in the upcoming 1.0.0 release.