### PR TITLE
fix: invalid type conversion in `api_version`

### DIFF
--- a/idlc_codegen_c/src/interface/mod.rs
+++ b/idlc_codegen_c/src/interface/mod.rs
@@ -193,7 +193,7 @@ pub fn emit_interface_invoke(interface: &Interface, is_no_typed_objects: bool) -
                 if (k != ObjectCounts_pack(0, 1, 0, 0) || a[0].b.size != 4) {{ \
                   break; \
                 }} \
-                uint32_t *a_ptr = (void*)a[0].b.ptr; \
+                uint32_t *a_ptr = (uint32_t*)a[0].b.ptr; \
                 *a_ptr = (({ident}_VERSION_MAJOR & {ident}_MAJOR_MASK) << {ident}_MAJOR_SHIFT) | \
                          (({ident}_VERSION_MINOR & {ident}_MINOR_MASK) << {ident}_MINOR_SHIFT) | \
                           ({ident}_VERSION_PATCH & {ident}_PATCH_MASK); \

--- a/tests/build.rs
+++ b/tests/build.rs
@@ -115,6 +115,7 @@ fn main() {
     c_ffi.file("c/invoke.c");
     c_ffi.include("c");
     c_ffi.include(c_generated(None));
+    c_ffi.flag("-Wc++-compat");
     c_ffi.flag("-Wno-unused-parameter");
     c_ffi.flag("-Werror");
     c_ffi.compile("c-ffi");


### PR DESCRIPTION
For C codegen only:

In the new versioning feature (introduced in 1.0.0), the type casting for the output buffer of the new `api_version` function is invalid _when using a C++ compiler_. C compilers do not report the error since in C (including C11), assigning `void*` to `T*` is perfectly legal [^1].

An error will be reported which looks similar to the following error:
```
| In file included from src/Service.cpp:15:
| src/Service.cpp: In function 'int32_t MyService_invoke(ObjectCxt, ObjectOp, ObjectArg*, ObjectCounts)':
| /path/to/service/sdk/ext/inc/IObject_invoke.h:34:49: error: invalid conversion from 'void*' to 'uint32_t*' {aka 'unsigned int*'} [-fpermissive]
|    34 |                 uint32_t *a_ptr = (void*)a[0].b.ptr; \
|       |                                          ~~~~~~~^~~
|       |                                                 |
|       |                                                 void*
| src/Service.cpp:42:1: note: in expansion of macro 'IObject_DEFINE_INVOKE'
|    42 | IObject_DEFINE_INVOKE(MyService_invoke, MyService_, MyService*);
|       | ^~~~~~~~~~~~~~~~~~~~~
```


---

The fix is to change the rhs type cast (`(void*)`) to match the lhs type (`uint32_t *`). That way both C and C++ compilers will accept the auto-generated `api_version` implementation.

[^1]: §6.3.2.3 defines the pointer type and its behavior in the C language [ISO/IEC 9899:201x](https://www.open-std.org/jtc1/sc22/wg14/www/docs/n1570.pdf)