### PR TITLE
Allow using constants defined in the IDL as array size values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to this project will be documented in this file.
 
+## [1.1.0](https://github.com/qualcomm/mink-idl-compiler/compare/v1.0.1...v1.1.0) (2026-06-11)
+
+### Enhancements
+- Allow using constants defined in the IDL as array size values.
+
 ## [1.0.1](https://github.com/qualcomm/mink-idl-compiler/compare/v1.0.0...v1.0.1) (2026-06-10)
 
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -304,6 +304,7 @@ name = "idlc_ast"
 version = "1.0.0"
 dependencies = [
  "idlc_errors",
+ "lazy_static",
  "pest",
  "pest_derive",
  "thiserror",
@@ -425,6 +426,12 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "lazy_static"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "libc"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,4 +27,4 @@ strip = true
 panic = "abort"
 
 [workspace.package]
-version = "1.0.1"
+version = "1.1.0"

--- a/idlc/Cargo.toml
+++ b/idlc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "idlc"
-version = "1.0.1"
+version = "1.1.0"
 edition = "2021"
 rust-version = "1.81.0"
 

--- a/idlc_ast/Cargo.toml
+++ b/idlc_ast/Cargo.toml
@@ -13,6 +13,7 @@ idlc_errors = {path = "../idlc_errors" }
 pest = "2.7.9"
 pest_derive = "2.7.9"
 thiserror = "1.0.59"
+lazy_static = "1.5.0"
 
 [package.metadata.workspaces]
 independent = true

--- a/idlc_ast/src/idl_grammar.pest
+++ b/idlc_ast/src/idl_grammar.pest
@@ -14,7 +14,7 @@ float_type     = @{ "float" ~ ("32" | "64") }
 primitive_type = @{ (integer_type | float_type) }
 value          = @{ ("-"? ~ "0x" ~ ASCII_HEX_DIGIT+ | "-"? ~ ASCII_DIGIT+ ~ ("." ~ ASCII_DIGIT+)?) }
 
-array_size      = @{ ASCII_DIGIT+ }
+array_size      = @{ ASCII_DIGIT+ | ident }
 bounded_array   =  { "[" ~ array_size ~ "]" }
 unbounded_array =  { "[" ~ "]" }
 

--- a/idlc_ast/src/pst.rs
+++ b/idlc_ast/src/pst.rs
@@ -1,6 +1,7 @@
 // Copyright (c) Qualcomm Technologies, Inc. and/or its subsidiaries.
 // SPDX-License-Identifier: BSD-3-Clause
 
+use std::collections::HashMap;
 use std::{path::PathBuf, rc::Rc};
 
 use pest::{
@@ -8,6 +9,16 @@ use pest::{
     Parser,
 };
 use pest_derive::Parser;
+
+use lazy_static::lazy_static;
+use std::sync::Mutex;
+
+lazy_static! {
+    static ref HASHMAP: Mutex<HashMap<String, String>> = {
+        let m = HashMap::new();
+        Mutex::new(m)
+    };
+}
 
 // Import all AST types
 use super::ast::{
@@ -192,6 +203,7 @@ impl From<Pair<'_, Rule>> for ParamTypeIn {
     fn from(rule: Pair<Rule>) -> Self {
         debug_assert_eq!(rule.as_rule(), Rule::param_type);
         let mut inner = rule.into_inner();
+        let map = HASHMAP.lock().unwrap();
         let r#type = Type::from(ast_unwrap!(inner.next()));
         if let Type::Custom(r#type) = &r#type {
             if r#type == "buffer" {
@@ -203,7 +215,18 @@ impl From<Pair<'_, Rule>> for ParamTypeIn {
             match pair.as_rule() {
                 Rule::unbounded_array => Self::Array(r#type, None),
                 Rule::bounded_array => {
-                    let array_len: Count = ast_unwrap!(pair.into_inner().as_str().parse());
+                    let array_val: String = ast_unwrap!(pair.into_inner().as_str().parse());
+                    let is_decimal = array_val.parse::<u16>();
+                    let array_len = match is_decimal {
+                        Ok(val) => Count::new(val).unwrap(),
+                        Err(_) => {
+                            if let Some(value) = map.get(&array_val) {
+                                Count::new(value.parse::<u16>().unwrap()).unwrap()
+                            } else {
+                                idlc_errors::unrecoverable!("Unknown variable {array_val}")
+                            }
+                        }
+                    };
                     Self::Array(r#type, Some(array_len))
                 }
                 _ => unreachable!(),
@@ -217,6 +240,7 @@ impl From<Pair<'_, Rule>> for ParamTypeOut {
     fn from(rule: Pair<Rule>) -> Self {
         debug_assert_eq!(rule.as_rule(), Rule::param_type);
         let mut inner = rule.into_inner();
+        let map = HASHMAP.lock().unwrap();
         let r#type = Type::from(ast_unwrap!(inner.next()));
         if let Type::Custom(r#type) = &r#type {
             if r#type == "buffer" {
@@ -228,7 +252,18 @@ impl From<Pair<'_, Rule>> for ParamTypeOut {
             match pair.as_rule() {
                 Rule::unbounded_array => Self::Array(r#type, None),
                 Rule::bounded_array => {
-                    let array_len: Count = ast_unwrap!(pair.into_inner().as_str().parse());
+                    let array_val: String = ast_unwrap!(pair.into_inner().as_str().parse());
+                    let is_decimal = array_val.parse::<u16>();
+                    let array_len = match is_decimal {
+                        Ok(val) => Count::new(val).unwrap(),
+                        Err(_) => {
+                            if let Some(value) = map.get(&array_val) {
+                                Count::new(value.parse::<u16>().unwrap()).unwrap()
+                            } else {
+                                idlc_errors::unrecoverable!("Unknown variable {array_val}")
+                            }
+                        }
+                    };
                     Self::Array(r#type, Some(array_len))
                 }
                 _ => unreachable!(),
@@ -269,6 +304,7 @@ fn parse_struct(pair: Pair<Rule>) -> Rc<Node> {
     let mut struct_pst = pair.into_inner().skip(1);
     let ident: Ident = ast_unwrap!(struct_pst.next()).into();
     let mut fields = Vec::<StructField>::new();
+    let map = HASHMAP.lock().unwrap();
     for rule in struct_pst {
         match rule.as_rule() {
             Rule::struct_field => {
@@ -277,8 +313,19 @@ fn parse_struct(pair: Pair<Rule>) -> Rc<Node> {
                 let next = ast_unwrap!(iter.next());
                 let (elem, ident) = match next.as_rule() {
                     Rule::bounded_array => {
-                        let array_len: Count =
+                        let array_val: String =
                             ast_unwrap!(next.clone().into_inner().as_str().parse());
+                        let is_decimal = array_val.parse::<u16>();
+                        let array_len = match is_decimal {
+                            Ok(val) => Count::new(val).unwrap(),
+                            Err(_) => {
+                                if let Some(value) = map.get(&array_val) {
+                                    Count::new(value.parse::<u16>().unwrap()).unwrap()
+                                } else {
+                                    idlc_errors::unrecoverable!("Unknown variable {array_val}")
+                                }
+                            }
+                        };
                         let ident = ast_unwrap!(iter.next()).as_str().to_string();
                         (array_len, ident)
                     }
@@ -310,7 +357,7 @@ fn parse_const(pair: Pair<Rule>, allow_undefined_behavior: bool) -> Const {
     let mut inner = pair.into_inner().skip(1);
 
     let ty = ast_unwrap!(inner.next()).as_str();
-    let ident = ast_unwrap!(inner.next()).into();
+    let ident: Ident = ast_unwrap!(inner.next()).into();
     let value = ast_unwrap!(inner.next()).as_str();
     let primitive = if allow_undefined_behavior {
         Primitive::try_from(ty).unwrap()
@@ -319,6 +366,8 @@ fn parse_const(pair: Pair<Rule>, allow_undefined_behavior: bool) -> Const {
             idlc_errors::unrecoverable!("'{value}' isn't in range for type '{ty}' [{e}]")
         })
     };
+    let mut map = HASHMAP.lock().unwrap();
+    map.insert(ident.to_string(), value.to_string());
 
     Const {
         ident,

--- a/idlc_codegen_cpp/src/generator.rs
+++ b/idlc_codegen_cpp/src/generator.rs
@@ -76,7 +76,6 @@ fn generate_common() -> String {
 #pragma once
 
 #include <cstdint>
-#include <stdint.h>
 #include "object.h"
 #include "proxy_base.hpp"
 "#

--- a/tests/idl/ITest.idl
+++ b/tests/idl/ITest.idl
@@ -28,8 +28,11 @@ struct F2 {
   uint8 b;
 };
 
+const uint32 CONST_VAL = 2;
+const uint32 CONST_VAL_INF = 3;
+
 struct ArrInStruct {
-  uint8[2] a;
+  uint8[CONST_VAL] a;
   F2[2] c;
   uint16 d;
 };
@@ -63,7 +66,7 @@ interface ITest1 {
   */
   method well_documented_method(in uint32 foo, out uint32 bar);
   method test_obj_array_in(in ITest1[3] o_in, out uint32 a);
-  method test_obj_array_out(out ITest1[3] out, out uint32 a);
+  method test_obj_array_out(out ITest1[CONST_VAL_INF] out, out uint32 a);
   method objects_in_struct(in ObjInStruct input, out ObjInStruct output);
   method no_args();
   method delete(in float64 key); // To show that reserved words are handled properly


### PR DESCRIPTION
This change is not mine. I only rebased #9 onto `main`.